### PR TITLE
Anira v2.1.0

### DIFF
--- a/.github/workflows/publish_web.yml
+++ b/.github/workflows/publish_web.yml
@@ -88,11 +88,12 @@ jobs:
         working-directory: web
         run: npm run build
 
+      # Trusted Publishing (OIDC): no NPM_TOKEN needed. npm >= 11.5.1 (pinned
+      # via packageManager) exchanges the GitHub OIDC token (id-token: write)
+      # for publish credentials and emits provenance automatically.
       - name: npm publish
         working-directory: web
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public --provenance --tag "${{ steps.meta.outputs.dist_tag }}"
+        run: npm publish --access public --tag "${{ steps.meta.outputs.dist_tag }}"
 
       - name: summary
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - RTSan real-time safety CI checks and testing (not done yet)
-- JSON configuration loader with nlohmann_json dependency (not done yet)
+
+## [v2.1.0] - 2026-06-14
+
+### Added
+
+- anira Web: the C++ library compiled to WebAssembly via Emscripten, published as the `@anira-project/anira` npm package
+  - Emscripten/embind C++ wrappers exposing the core API (InferenceHandler, InferenceConfig, PrePostProcessor, ProcessingSpec, InferenceThread, Buffer, RingBuffer, HostConfig) to JavaScript
+  - TypeScript API layer wrapping these bindings (`AniraWeb`, plus typed wrappers for InferenceHandler, InferenceConfig, ModelData, TensorShape, ProcessingSpec, BufferF, RingBuffer, HostConfig and the embind Vector types)
+  - New ONNXRuntimeWebBackend (onnxruntime-web), plus `JSBackendBase`/`JSPrePostProcessor` hooks for implementing custom inference backends and pre/post processing in JavaScript/TypeScript
+  - Web Audio API integration with an AudioWorklet base class and Web Worker–based off-thread inference
+  - WASM build tooling (BuildWasm.cmake, DetectEmscripten.cmake, CMake presets), npm publish workflows, and dedicated Web API documentation (Sphinx + TypeDoc)
+- `anira::Semaphore` wrapper for macOS 10.13 support
+- macOS universal binary support: anira can now be built as a universal binary (arm64 + x86_64) when no pre-built backends are enabled (e.g. for a custom CoreML backend)
+- tanh-lib submodule with clang-format and clang-tidy support
+- Unregistering of pre/post processors and a prePostRegistry
+- Validation that the maximum inference time must be greater than 0
+- Function for freeing the stack pointer
+- Sponsor information in the README
+
+### Changed
+
+- Enforce stateful model inference ordering via single-in-flight dispatch instead of spin-wait
+- MSVC: support static linking via `ANIRA_STATIC_DEFINE`
+- Refactored processPrePost
+- Improved GitHub Actions workflows (node24, new workflow versions, no env vars)
+- Added Prettier formatting
+
+### Fixed
+
+- Fixed a Windows build bug
+- Fixed the documentation build step
+- Fixed npm version drift (pinned onnxruntime-web to 1.19.2)
+
+## [v2.0.3] - 2025-11-07
+
+### Added
+
+- JSON configuration loader (JsonConfigLoader) with nlohmann_json dependency, including unit tests
+- Option to load LibTorch models as binary data
+- `model_function` argument for `model_data` in the JsonConfigLoader
+- JSON gain example config and JUCE plugin example with JSON inference config loading
+- no_grad options for torch tensors and the inference stage (Fixes #45)
+
+### Fixed
+
+- JUCE plugin example failing to compile when MODEL_TO_USE is set to 6
+- No-inference-engine CI build (JsonConfigLoader excluded from the no_inference_engine build)
+- Missing preprocessor flag in RaveFunkDrumConfig.h
 
 ## [v2.0.2] - 2025-08-03
 

--- a/cmake/SetupOnnxRuntime.cmake
+++ b/cmake/SetupOnnxRuntime.cmake
@@ -50,11 +50,46 @@ else()
     endif()
     
     message(STATUS "Downloading: ${LIBONNXRUNTIME_URL}")
-    
+
     set(LIBONNXRUNTIME_PATH ${CMAKE_BINARY_DIR}/import/${LIB_ONNXRUNTIME_PRE_BUILD_LIB_NAME}.${LIB_ONNXRUNTIME_PRE_BUILD_LIB_TYPE})
 
     file(DOWNLOAD ${LIBONNXRUNTIME_URL} ${LIBONNXRUNTIME_PATH} STATUS LIBONNXRUNTIME_DOWNLOAD_STATUS SHOW_PROGRESS)
     list(GET LIBONNXRUNTIME_DOWNLOAD_STATUS 0 LIBONNXRUNTIME_DOWNLOAD_STATUS_NO)
+    list(GET LIBONNXRUNTIME_DOWNLOAD_STATUS 1 LIBONNXRUNTIME_DOWNLOAD_STATUS_MSG)
+
+    # file(DOWNLOAD) does not treat HTTP errors (e.g. a 404 for a missing release
+    # asset) as failures - GitHub returns a small "Not Found" body that libcurl
+    # reports as a successful transfer. Detect that case via the downloaded size:
+    # a real archive is far larger than any error page.
+    set(LIBONNXRUNTIME_DOWNLOAD_SIZE 0)
+    if(EXISTS ${LIBONNXRUNTIME_PATH})
+        file(SIZE ${LIBONNXRUNTIME_PATH} LIBONNXRUNTIME_DOWNLOAD_SIZE)
+    endif()
+
+    if(LIBONNXRUNTIME_DOWNLOAD_STATUS_NO OR LIBONNXRUNTIME_DOWNLOAD_SIZE LESS 1024)
+        file(REMOVE_RECURSE ${ONNXRUNTIME_ROOTDIR})
+        file(REMOVE ${LIBONNXRUNTIME_PATH})
+        if(EMSDK_VERSION)
+            message(FATAL_ERROR
+                "Incompatible Emscripten version: no pre-built ONNX Runtime "
+                "v${LIBONNXRUNTIME_VERSION} WebAssembly library is available for "
+                "Emscripten ${EMSDK_VERSION}.\n"
+                "  Download failed: ${LIBONNXRUNTIME_URL}\n"
+                "  Reason: ${LIBONNXRUNTIME_DOWNLOAD_STATUS_MSG}\n"
+                "Pre-built WASM libraries are published per Emscripten version at\n"
+                "  https://github.com/Andonvr/ONNXRuntime-Static-WASM-Builds/releases\n"
+                "Install and activate a supported Emscripten version (one with an "
+                "'emsdk-<version>-onnx-v${LIBONNXRUNTIME_VERSION}' release), e.g.:\n"
+                "  ./emsdk install <version> && ./emsdk activate <version>\n"
+                "then re-run CMake configure.")
+        else()
+            message(FATAL_ERROR
+                "Failed to download pre-built ONNX Runtime library.\n"
+                "  URL: ${LIBONNXRUNTIME_URL}\n"
+                "  Reason: ${LIBONNXRUNTIME_DOWNLOAD_STATUS_MSG}\n"
+                "Check your network connection and cmake/SetupOnnxRuntime.cmake.")
+        endif()
+    endif()
 
     if(UNIX AND NOT APPLE AND CMAKE_SYSTEM_PROCESSOR STREQUAL "armv7l")
         execute_process(
@@ -69,15 +104,23 @@ else()
     if(EXISTS ${ONNXRUNTIME_ROOTDIR}/${LIB_ONNXRUNTIME_PRE_BUILD_LIB_NAME}/)
         file(COPY ${ONNXRUNTIME_ROOTDIR}/${LIB_ONNXRUNTIME_PRE_BUILD_LIB_NAME}/ DESTINATION ${ONNXRUNTIME_ROOTDIR}/)
         file(REMOVE_RECURSE ${ONNXRUNTIME_ROOTDIR}/${LIB_ONNXRUNTIME_PRE_BUILD_LIB_NAME})
-    endif()   
-        
-    if(LIBONNXRUNTIME_DOWNLOAD_STATUS_NO)
-        message(STATUS "Pre-built library not downloaded. Error occurred, try again and check cmake/SetupOnnxRuntime.cmake")
+    endif()
+
+    # Sanity-check that the archive actually contained the WebAssembly static lib
+    # that CMakeLists.txt links against. Guards against a valid-but-unexpected
+    # archive layout silently producing the cryptic "missing and no known rule" ninja error.
+    if(EMSDK_VERSION AND NOT EXISTS ${ONNXRUNTIME_ROOTDIR}/libonnxruntime_webassembly.a)
         file(REMOVE_RECURSE ${ONNXRUNTIME_ROOTDIR})
         file(REMOVE ${LIBONNXRUNTIME_PATH})
-    else()
-        message(STATUS "Linking downloaded ONNX-Runtime pre-built library.")
+        message(FATAL_ERROR
+            "Downloaded ONNX Runtime archive for Emscripten ${EMSDK_VERSION} did not "
+            "contain the expected 'libonnxruntime_webassembly.a'.\n"
+            "  URL: ${LIBONNXRUNTIME_URL}\n"
+            "The pre-built archive layout may have changed - check "
+            "cmake/SetupOnnxRuntime.cmake.")
     endif()
+
+    message(STATUS "Linking downloaded ONNX-Runtime pre-built library.")
 endif()
 
 set(ANIRA_ONNXRUNTIME_SHARED_LIB_PATH "${ONNXRUNTIME_ROOTDIR}")

--- a/docs/sphinx/api/class/classanira_1_1_semaphore.rst
+++ b/docs/sphinx/api/class/classanira_1_1_semaphore.rst
@@ -1,0 +1,5 @@
+Class anira::Semaphore
+======================
+
+.. doxygenclass:: anira::Semaphore
+    :allow-dot-graphs:


### PR DESCRIPTION
Release v2.1.0.

Updates `CHANGELOG.md` with the `v2.0.3` and `v2.1.0` sections, plus the ONNX Runtime CMake setup changes and the `anira::Semaphore` doc page.

See the [CHANGELOG](CHANGELOG.md) for the full list of changes.