### PR TITLE
ci(web): use Node 24 for npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish_web.yml
+++ b/.github/workflows/publish_web.yml
@@ -52,7 +52,10 @@ jobs:
       - name: setup node
         uses: actions/setup-node@v5
         with:
-          node-version: '22'
+          # Node 24 ships npm >= 11 and is required for the npm OIDC
+          # trusted-publishing handshake; Node 22 (npm 10) authenticates
+          # anonymously and the publish fails with a misleading E404.
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
@@ -93,7 +96,10 @@ jobs:
       # for publish credentials and emits provenance automatically.
       - name: npm publish
         working-directory: web
-        run: npm publish --access public --tag "${{ steps.meta.outputs.dist_tag }}"
+        run: |
+          node --version
+          npm --version   # must be >= 11.5.1 for OIDC trusted publishing
+          npm publish --access public --tag "${{ steps.meta.outputs.dist_tag }}"
 
       - name: summary
         shell: bash


### PR DESCRIPTION
The \`publish_web\` workflow publishes \`@anira-project/anira\` via npm OIDC Trusted Publishing, but every run failed with a misleading \`E404\` on the publish \`PUT\`.

**Root cause:** the publish ran on Node 22, whose system npm (v10) does not perform the OIDC trusted-publishing handshake. npm therefore authenticated anonymously, and the registry masks the resulting \`403 Not Authorized\` as a \`404 Not Found\`.

**Fix:** bump \`setup-node\` to Node 24 (ships npm >= 11). Also print \`node\`/\`npm\` versions before publishing to make any future auth issue obvious.

After merge, the \`v2.1.0\` tag must be moved to the merge commit and re-pushed to trigger a publish from the fixed workflow.