### PR TITLE
Clang-tidy conformance

### DIFF
--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -1,0 +1,41 @@
+name: clang_tidy
+
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tidy:
+    name: clang-tidy
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        include:
+          - name: Linux-x86_64
+            os: ubuntu-24.04
+    steps:
+      # submodules: true is required because .clang-tidy is a symlink into
+      # modules/tanh-lib; without it the symlink dangles and clang-tidy
+      # silently falls back to the default checks.
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+      - uses: tanh-lab/ci-actions/setup-cpp-build-tools@main
+      # clang-tidy needs a compile_commands.json, so the library is configured
+      # and built first. The clang-tidy preset enables tests, the benchmark
+      # fixture and all backends so every analysed translation unit compiles.
+      - uses: tanh-lab/ci-actions/cmake-build@main
+        with:
+          PRESET: clang-tidy
+      # SOURCES excludes src/emscripten-wrappers/ because those translation
+      # units are only built by the wasm presets (Emscripten toolchain) and are
+      # therefore absent from this build's compilation database.
+      - uses: tanh-lab/ci-actions/clang-tidy-check@main
+        with:
+          PRESET: clang-tidy
+          SOURCES: "src/backends/ src/benchmark/ src/scheduler/ src/system/ src/utils/ src/InferenceConfig.cpp src/InferenceHandler.cpp src/PrePostProcessor.cpp test/"

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ extras/models/cnn/steerable-nafx/
 extras/models/model-pool/example-models/
 extras/models/third-party/ircam-acids/RAVE/
 extras/**/*.json
+.cache/
 
 # Auto-generated TypeDoc artifacts for the Anira Web docs (consumed by sphinx-js).
 docs/typedoc/node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - RTSan real-time safety CI checks and testing (not done yet)
+- clang-tidy conformance across the library, tests and benchmark sources, enforced in CI via the `tanh-lab/ci-actions/clang-tidy-check` action (`clang_tidy.yml`)
+
+### Changed
+
+- **Breaking:** the `InferenceConfig::Defaults` compile-time constants were renamed from the `m_` prefix to the `k_` prefix to match the constant-naming convention (`m_warm_up` → `k_warm_up`, `m_session_exclusive_processor` → `k_session_exclusive_processor`, `m_blocking_ratio` → `k_blocking_ratio`). The mutable `Defaults::m_num_parallel_processors` is unchanged.
+- `anira::calculate_min` / `anira::calculate_max` are now `inline` free functions instead of `const auto` lambdas (source-compatible: existing call sites and uses as a callable are unaffected)
+- The internal logging helper `isLoggingEnabled()` was renamed to `is_logging_enabled()`
+
+### Fixed
+
+- Potential use-after-free in `Buffer::malloc_channels()` when channel-pointer allocation fails
 
 ## [v2.1.0] - 2026-06-14
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -29,6 +29,24 @@
       }
     },
     {
+      "name": "clang-tidy",
+      "displayName": "Clang-Tidy",
+      "description": "Library + tests + benchmark build with all backends, used for clang-tidy analysis (exports compile_commands.json)",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/clang-tidy",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "ANIRA_WITH_TESTS": "ON",
+        "ANIRA_WITH_BENCHMARK": "ON",
+        "ANIRA_WITH_LIBTORCH": "ON",
+        "ANIRA_WITH_ONNXRUNTIME": "ON",
+        "ANIRA_WITH_TFLITE": "ON"
+      }
+    },
+    {
       "name": "wasm-debug",
       "displayName": "Wasm Debug",
       "description": "Build AniraWeb WASM module (debug)",
@@ -83,6 +101,11 @@
       "name": "desktop-release",
       "configurePreset": "desktop-release",
       "configuration": "Release"
+    },
+    {
+      "name": "clang-tidy",
+      "configurePreset": "clang-tidy",
+      "configuration": "Debug"
     },
     {
       "name": "wasm-debug",

--- a/include/anira/InferenceConfig.h
+++ b/include/anira/InferenceConfig.h
@@ -10,13 +10,14 @@
 #include <iostream>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 #include "anira/system/AniraWinExports.h"
 
 namespace anira {
 
-typedef std::vector<std::vector<int64_t>> TensorShapeList;
+using TensorShapeList = std::vector<std::vector<int64_t>>;
 
 /**
  * @brief Container for neural network model data and metadata
@@ -45,7 +46,7 @@ struct ANIRA_API ModelData {
         : m_data(data)
         , m_size(size)
         , m_backend(backend)
-        , m_model_function(std::move(model_function))
+        , m_model_function(model_function)
         , m_is_binary(is_binary) {
         assert((m_size > 0 && "Model data size must be greater than zero."));
         assert((m_data != nullptr && "Model data pointer cannot be null."));
@@ -54,7 +55,7 @@ struct ANIRA_API ModelData {
             if (backend == InferenceBackend::LIBTORCH) {
                 m_model_function = model_function;  // For LIBTORCH, we can specify a function name
             } else {
-                LOG_ERROR << "Model function is only applicable for LIBTORCH backend." << std::endl;
+                LOG_ERROR << "Model function is only applicable for LIBTORCH backend." << '\n';
             }
 #else
             LOG_ERROR << "Model function is only applicable for LIBTORCH backend (LIBTORCH "
@@ -86,7 +87,7 @@ struct ANIRA_API ModelData {
         : ModelData((void*)model_path.data(),
                     model_path.size(),
                     backend,
-                    std::move(model_function),
+                    model_function,
                     is_binary) {}
 
     /**
@@ -216,7 +217,8 @@ struct ANIRA_API TensorShape {
      * @param output_shape List of output tensor shapes, where each shape is a vector of dimensions
      */
     TensorShape(TensorShapeList input_shape, TensorShapeList output_shape)
-        : m_tensor_input_shape(input_shape), m_tensor_output_shape(output_shape) {
+        : m_tensor_input_shape(std::move(std::move(input_shape)))
+        , m_tensor_output_shape(std::move(std::move(output_shape))) {
         assert((m_tensor_input_shape.size() > 0 && "At least one input shape must be provided."));
         assert((m_tensor_output_shape.size() > 0 && "At least one output shape must be provided."));
         m_universal = true;
@@ -234,8 +236,8 @@ struct ANIRA_API TensorShape {
      * @param backend The specific inference backend this shape configuration targets
      */
     TensorShape(TensorShapeList input_shape, TensorShapeList output_shape, InferenceBackend backend)
-        : m_tensor_input_shape(input_shape)
-        , m_tensor_output_shape(output_shape)
+        : m_tensor_input_shape(std::move(std::move(input_shape)))
+        , m_tensor_output_shape(std::move(std::move(output_shape)))
         , m_backend(backend) {
         assert((m_tensor_input_shape.size() > 0 && "At least one input shape must be provided."));
         assert((m_tensor_output_shape.size() > 0 && "At least one output shape must be provided."));
@@ -435,12 +437,12 @@ public:
      * parameters, ensuring consistent behavior across different usage scenarios.
      */
     struct Defaults {
-        static constexpr unsigned int m_warm_up = 0;  ///< Default number of warm-up inferences (0 =
+        static constexpr unsigned int k_warm_up = 0;  ///< Default number of warm-up inferences (0 =
                                                       ///< no warm-up)
-        static constexpr bool m_session_exclusive_processor = false;  ///< Default session
+        static constexpr bool k_session_exclusive_processor = false;  ///< Default session
                                                                       ///< exclusivity (false =
                                                                       ///< shared processors)
-        static constexpr float m_blocking_ratio = 0.f;  ///< Default blocking ratio (0.0 =
+        static constexpr float k_blocking_ratio = 0.f;  ///< Default blocking ratio (0.0 =
                                                         ///< non-blocking)
 
         /// Default number of parallel processors (half of available hardware threads, minimum 1)
@@ -477,9 +479,9 @@ public:
                     std::vector<TensorShape> tensor_shape,
                     ProcessingSpec processing_spec,
                     float max_inference_time,                    // in ms per inference
-                    unsigned int warm_up = Defaults::m_warm_up,  // number of warm up inferences
-                    bool session_exclusive_processor = Defaults::m_session_exclusive_processor,
-                    float blocking_ratio = Defaults::m_blocking_ratio,
+                    unsigned int warm_up = Defaults::k_warm_up,  // number of warm up inferences
+                    bool session_exclusive_processor = Defaults::k_session_exclusive_processor,
+                    float blocking_ratio = Defaults::k_blocking_ratio,
                     unsigned int num_parallel_processors = Defaults::m_num_parallel_processors);
 
     /**
@@ -500,9 +502,9 @@ public:
     InferenceConfig(std::vector<ModelData> model_data,
                     std::vector<TensorShape> tensor_shape,
                     float max_inference_time,                    // in ms per inference
-                    unsigned int warm_up = Defaults::m_warm_up,  // number of warm up inferences
-                    bool session_exclusive_processor = Defaults::m_session_exclusive_processor,
-                    float blocking_ratio = Defaults::m_blocking_ratio,
+                    unsigned int warm_up = Defaults::k_warm_up,  // number of warm up inferences
+                    bool session_exclusive_processor = Defaults::k_session_exclusive_processor,
+                    float blocking_ratio = Defaults::k_blocking_ratio,
                     unsigned int num_parallel_processors = Defaults::m_num_parallel_processors)
         : InferenceConfig(std::move(model_data),
                           std::move(tensor_shape),

--- a/include/anira/backends/LibTorchProcessor.h
+++ b/include/anira/backends/LibTorchProcessor.h
@@ -140,7 +140,7 @@ private:
          */
         void process(std::vector<BufferF>& input,
                      std::vector<BufferF>& output,
-                     std::shared_ptr<SessionElement> session);
+                     const std::shared_ptr<SessionElement>& session);
 
         torch::jit::script::Module m_module;  ///< Loaded TorchScript model for inference
 

--- a/include/anira/backends/OnnxRuntimeProcessor.h
+++ b/include/anira/backends/OnnxRuntimeProcessor.h
@@ -109,7 +109,7 @@ private:
          */
         void process(std::vector<BufferF>& input,
                      std::vector<BufferF>& output,
-                     std::shared_ptr<SessionElement> session);
+                     const std::shared_ptr<SessionElement>& session);
 
         Ort::MemoryInfo m_memory_info;                 ///< Memory information for tensor allocation
         Ort::Env m_env;                                ///< ONNX Runtime environment

--- a/include/anira/backends/TFLiteProcessor.h
+++ b/include/anira/backends/TFLiteProcessor.h
@@ -112,7 +112,7 @@ private:
          */
         void process(std::vector<BufferF>& input,
                      std::vector<BufferF>& output,
-                     std::shared_ptr<SessionElement> session);
+                     const std::shared_ptr<SessionElement>& session);
 
         TfLiteModel* m_model;                 ///< TensorFlow Lite model loaded from file
         TfLiteInterpreterOptions* m_options;  ///< Interpreter configuration options

--- a/include/anira/benchmark/ProcessBlockFixture.h
+++ b/include/anira/benchmark/ProcessBlockFixture.h
@@ -8,8 +8,7 @@
 #include "../anira.h"
 #include "../utils/helperFunctions.h"
 
-namespace anira {
-namespace benchmark {
+namespace anira::benchmark {
 
 /**
  * @brief Benchmark fixture class for testing neural network inference performance in audio
@@ -44,7 +43,7 @@ public:
     /**
      * @brief Destructor that cleans up benchmark resources
      */
-    ~ProcessBlockFixture();
+    ~ProcessBlockFixture() override;
 
     /**
      * @brief Initializes the current benchmark iteration
@@ -171,7 +170,8 @@ private:
      *
      * @param state The benchmark state containing runtime parameters
      */
-    void SetUp(const ::benchmark::State& state);
+    // NOLINTNEXTLINE(readability-identifier-naming) - overrides ::benchmark::Fixture::SetUp
+    void SetUp(const ::benchmark::State& state) override;
 
     /**
      * @brief Cleans up the benchmark fixture after each benchmark run
@@ -182,10 +182,10 @@ private:
      *
      * @param state The benchmark state containing runtime parameters
      */
-    void TearDown(const ::benchmark::State& state);
+    // NOLINTNEXTLINE(readability-identifier-naming) - overrides ::benchmark::Fixture::TearDown
+    void TearDown(const ::benchmark::State& state) override;
 };
 
-}  // namespace benchmark
-}  // namespace anira
+}  // namespace anira::benchmark
 
 #endif  // ANIRA_BENCHMARK_PROCESSBLOCKFIXTURE_H

--- a/include/anira/scheduler/Context.h
+++ b/include/anira/scheduler/Context.h
@@ -23,9 +23,6 @@
 #include "../backends/TFLiteProcessor.h"
 #endif
 
-#define MIN_CAPACITY_INFERENCE_QUEUE 10000
-#define MAX_NUM_INSTANCES 1000
-
 namespace anira {
 
 /**
@@ -74,7 +71,7 @@ public:
      * Properly shuts down the thread pool, releases all backend processors,
      * and cleans up any remaining sessions or inference data.
      */
-    ~Context();
+    ~Context() = default;
     /**
      * @brief Gets or creates the singleton context instance
      *
@@ -115,7 +112,7 @@ public:
      *
      * @param session Shared pointer to the session to release
      */
-    static void release_session(std::shared_ptr<SessionElement> session);
+    static void release_session(const std::shared_ptr<SessionElement>& session);
 
     /**
      * @brief Releases the singleton context instance
@@ -145,7 +142,7 @@ public:
      * @param new_config New host configuration with audio settings
      * @param custom_latency Optional vector of custom latency values for each tensor
      */
-    void prepare_session(std::shared_ptr<SessionElement> session,
+    void prepare_session(const std::shared_ptr<SessionElement>& session,
                          HostConfig new_config,
                          std::vector<long> custom_latency = {});
 
@@ -168,7 +165,7 @@ public:
      *
      * @param session Shared pointer to the session that has new data available
      */
-    void new_data_submitted(std::shared_ptr<SessionElement> session);
+    void new_data_submitted(const std::shared_ptr<SessionElement>& session);
 
     /**
      * @brief Requests new data processing for a session
@@ -179,7 +176,7 @@ public:
      *
      * @param session Shared pointer to the session requesting data processing
      */
-    void new_data_request(std::shared_ptr<SessionElement> session);
+    void new_data_request(const std::shared_ptr<SessionElement>& session);
 
     /**
      * @brief Requests new data processing for a session at a specific time
@@ -190,7 +187,7 @@ public:
      * @param session Shared pointer to the session requesting data processing
      * @param wait_until Time point at which to begin processing the data request
      */
-    void new_data_request(std::shared_ptr<SessionElement> session,
+    void new_data_request(const std::shared_ptr<SessionElement>& session,
                           std::chrono::steady_clock::time_point wait_until);
 
     /**
@@ -215,7 +212,7 @@ public:
      *
      * @param session Shared pointer to the session to reset
      */
-    void reset_session(std::shared_ptr<SessionElement> session);
+    void reset_session(const std::shared_ptr<SessionElement>& session);
 
     /**
      * @brief Get producer token for the next inference request
@@ -288,7 +285,7 @@ private:
      * @param session Shared pointer to the session to preprocess
      * @return True if preprocessing was successful, false otherwise
      */
-    static bool pre_process(std::shared_ptr<SessionElement> session);
+    static bool pre_process(const std::shared_ptr<SessionElement>& session);
 
     /**
      * @brief Performs postprocessing for a session
@@ -299,8 +296,8 @@ private:
      * @param session Shared pointer to the session to postprocess
      * @param next_buffer Shared pointer to thread-safe data structures for the session
      */
-    static void post_process(std::shared_ptr<SessionElement> session,
-                             std::shared_ptr<SessionElement::ThreadSafeStruct> next_buffer);
+    static void post_process(const std::shared_ptr<SessionElement>& session,
+                             const std::shared_ptr<SessionElement::ThreadSafeStruct>& next_buffer);
 
     /**
      * @brief Starts the inference thread pool
@@ -321,7 +318,7 @@ private:
      *
      * @warning Make sure to uninitialize the session before calling this method.
      */
-    static void drain_inference_queue(std::shared_ptr<SessionElement> session);
+    static void drain_inference_queue(const std::shared_ptr<SessionElement>& session);
 
     /**
      * @brief Template method for setting backend processors
@@ -337,7 +334,7 @@ private:
      * @param backend Backend type identifier
      */
     template <typename T>
-    static void set_processor(std::shared_ptr<SessionElement> session,
+    static void set_processor(const std::shared_ptr<SessionElement>& session,
                               InferenceConfig& inference_config,
                               std::vector<std::shared_ptr<T>>& processors,
                               InferenceBackend backend);
@@ -384,6 +381,12 @@ private:
                                                                  ///< generating unique producer
                                                                  ///< indices
 
+    static constexpr size_t k_min_capacity_inference_queue = 10000;  ///< Minimum pre-allocated
+                                                                     ///< capacity of the inference
+                                                                     ///< queue
+    static constexpr size_t k_max_num_instances = 1000;  ///< Maximum number of explicit producers
+                                                         ///< for the inference queue
+
     /**
      * @brief Thread-safe concurrent queue for inference requests
      *
@@ -392,9 +395,9 @@ private:
      * to ensure efficient memory usage and prevent resource exhaustion.
      */
     inline static moodycamel::ConcurrentQueue<InferenceData> m_next_inference =
-        moodycamel::ConcurrentQueue<InferenceData>(MIN_CAPACITY_INFERENCE_QUEUE,
+        moodycamel::ConcurrentQueue<InferenceData>(k_min_capacity_inference_queue,
                                                    0,
-                                                   MAX_NUM_INSTANCES);
+                                                   k_max_num_instances);
 
 #ifdef USE_LIBTORCH
     inline static std::vector<std::shared_ptr<LibtorchProcessor>>

--- a/include/anira/scheduler/InferenceThread.h
+++ b/include/anira/scheduler/InferenceThread.h
@@ -127,8 +127,8 @@ private:
      * @param session Shared pointer to the SessionElement containing inference configuration
      * @param thread_safe_struct Shared pointer to thread-safe data structures for the session
      */
-    void do_inference(std::shared_ptr<SessionElement> session,
-                      std::shared_ptr<SessionElement::ThreadSafeStruct> thread_safe_struct);
+    void do_inference(const std::shared_ptr<SessionElement>& session,
+                      const std::shared_ptr<SessionElement::ThreadSafeStruct>& thread_safe_struct);
 
     /**
      * @brief Executes the core inference operation with input/output buffers
@@ -141,7 +141,7 @@ private:
      * @param input Vector of input buffers containing the audio data to process
      * @param output Vector of output buffers to receive the processed results
      */
-    void inference(std::shared_ptr<SessionElement> session,
+    void inference(const std::shared_ptr<SessionElement>& session,
                    std::vector<BufferF>& input,
                    std::vector<BufferF>& output);
 

--- a/include/anira/scheduler/SessionElement.h
+++ b/include/anira/scheduler/SessionElement.h
@@ -15,23 +15,14 @@
 #include "../utils/RingBuffer.h"
 #include "../utils/Semaphore.h"
 
-#ifdef USE_LIBTORCH
-#include "../backends/LibTorchProcessor.h"
-#endif
-#ifdef USE_ONNXRUNTIME
-#include "../backends/OnnxRuntimeProcessor.h"
-#endif
-#ifdef USE_TFLITE
-#include "../backends/TFLiteProcessor.h"
-#endif
-
 namespace anira {
 
 /**
  * @brief Forward declarations to resolve circular dependencies
  *
- * These forward declarations are necessary due to circular dependencies between
- * SessionElement and the various backend processor classes.
+ * The backend processor classes include SessionElement.h, so SessionElement only
+ * forward-declares them here and holds them via std::shared_ptr (which does not
+ * require a complete type). This breaks the otherwise circular include dependency.
  */
 class BackendBase;
 #ifdef USE_LIBTORCH
@@ -77,11 +68,11 @@ public:
      * the provided preprocessing/postprocessing pipeline and inference configuration.
      * The session is not fully initialized until prepare() is called.
      *
-     * @param newSessionID Unique identifier for this session
+     * @param new_session_id Unique identifier for this session
      * @param pp_processor Reference to the preprocessing/postprocessing pipeline
      * @param inference_config Reference to the inference configuration containing model settings
      */
-    SessionElement(int newSessionID,
+    SessionElement(int new_session_id,
                    PrePostProcessor& pp_processor,
                    InferenceConfig& inference_config);
 
@@ -191,8 +182,8 @@ public:
          * @param tensor_input_size Vector of input tensor sizes
          * @param tensor_output_size Vector of output tensor sizes
          */
-        ThreadSafeStruct(std::vector<size_t> tensor_input_size,
-                         std::vector<size_t> tensor_output_size);
+        ThreadSafeStruct(const std::vector<size_t>& tensor_input_size,
+                         const std::vector<size_t>& tensor_output_size);
 
         std::atomic<bool> m_free{true};  ///< Atomic flag indicating if this structure is available
                                          ///< for use

--- a/include/anira/utils/Buffer.h
+++ b/include/anira/utils/Buffer.h
@@ -106,7 +106,7 @@ public:
      * Automatically frees the memory allocated for channel pointers. The underlying
      * audio data memory is managed by the MemoryBlock and cleaned up automatically.
      */
-    ~Buffer() { free(m_channels); }
+    ~Buffer() { free(static_cast<void*>(m_channels)); }
 
     /**
      * @brief Copy assignment operator that replaces this buffer's content with another buffer's
@@ -120,7 +120,7 @@ public:
      */
     Buffer& operator=(const Buffer& other) {
         if (this != &other) {
-            free(m_channels);
+            free(static_cast<void*>(m_channels));
             m_num_channels = other.m_num_channels;
             m_size = other.m_size;
             m_data = other.m_data;
@@ -142,7 +142,7 @@ public:
      */
     Buffer& operator=(Buffer&& other) noexcept {
         if (this != &other) {
-            free(m_channels);
+            free(static_cast<void*>(m_channels));
             m_num_channels = other.m_num_channels;
             m_size = other.m_size;
             m_data = std::move(other.m_data);
@@ -171,7 +171,7 @@ public:
         m_num_channels = num_channels;
         m_size = size;
         m_data.resize(num_channels * size);
-        free(m_channels);
+        free(static_cast<void*>(m_channels));
         malloc_channels();
     }
 
@@ -301,7 +301,7 @@ public:
                 other.m_channels = temp_channels;
             } else {
                 LOG_ERROR << "Cannot swap data, buffers have different number of channels or sizes!"
-                          << std::endl;
+                          << '\n';
             }
         }
     }
@@ -322,7 +322,7 @@ public:
             m_data.swap_data(other);
             reset_channel_ptr();
         } else {
-            LOG_ERROR << "Cannot swap data, MemoryBlock has a different size!" << std::endl;
+            LOG_ERROR << "Cannot swap data, MemoryBlock has a different size!" << '\n';
         }
     }
 
@@ -343,7 +343,7 @@ public:
             m_data.swap_data(data, size);
             reset_channel_ptr();
         } else {
-            LOG_ERROR << "Cannot swap data, MemoryBlock has a different size!" << std::endl;
+            LOG_ERROR << "Cannot swap data, MemoryBlock has a different size!" << '\n';
         }
     }
 
@@ -406,10 +406,13 @@ private:
         void* channels = malloc(m_num_channels * sizeof(T*));
         if (channels != nullptr) {
             m_channels = (T**)channels;
+            for (size_t i = 0; i < m_num_channels; i++) {
+                m_channels[i] = m_data.data() + i * m_size;
+            }
         } else {
-            LOG_ERROR << "Failed to allocate memory!" << std::endl;
+            m_channels = nullptr;
+            LOG_ERROR << "Failed to allocate memory!" << '\n';
         }
-        for (size_t i = 0; i < m_num_channels; i++) { m_channels[i] = m_data.data() + i * m_size; }
     }
 
     size_t m_num_channels = 0;  ///< Number of audio channels in the buffer

--- a/include/anira/utils/HostConfig.h
+++ b/include/anira/utils/HostConfig.h
@@ -113,7 +113,7 @@ struct ANIRA_API HostConfig {
     float get_relative_buffer_size(const InferenceConfig& inference_config,
                                    size_t tensor_index,
                                    bool input = true) const {
-        float ratio_buffer_size =
+        float const ratio_buffer_size =
             m_buffer_size /
             static_cast<float>(inference_config.get_preprocess_input_size()[m_tensor_index]);
         if (input) {
@@ -149,7 +149,7 @@ struct ANIRA_API HostConfig {
     float get_relative_sample_rate(const InferenceConfig& inference_config,
                                    size_t tensor_index,
                                    bool input = true) const {
-        float ratio_sample_rate =
+        float const ratio_sample_rate =
             m_sample_rate /
             static_cast<float>(inference_config.get_preprocess_input_size()[m_tensor_index]);
         if (input) {

--- a/include/anira/utils/JsonConfigLoader.h
+++ b/include/anira/utils/JsonConfigLoader.h
@@ -21,10 +21,10 @@ private:
     struct SingleParameterStruct {
         bool m_max_inference_time_set = false;
         float m_max_inference_time = 0.f;
-        unsigned int m_warm_up = anira::InferenceConfig::Defaults::m_warm_up;
+        unsigned int m_warm_up = anira::InferenceConfig::Defaults::k_warm_up;
         bool m_session_exclusive_processor =
-            anira::InferenceConfig::Defaults::m_session_exclusive_processor;
-        float m_blocking_ratio = anira::InferenceConfig::Defaults::m_blocking_ratio;
+            anira::InferenceConfig::Defaults::k_session_exclusive_processor;
+        float m_blocking_ratio = anira::InferenceConfig::Defaults::k_blocking_ratio;
         unsigned int m_num_parallel_processors =
             anira::InferenceConfig::Defaults::m_num_parallel_processors;
     };
@@ -44,7 +44,7 @@ private:
         const nlohmann::basic_json<>& config,
         bool& config_required);
     static std::vector<size_t> parse_size_t_json_shape(const nlohmann::json& shape_node,
-                                                       std::string json_key_name);
+                                                       const std::string& json_key_name);
     static SingleParameterStruct create_single_parameters_from_config(
         const nlohmann::basic_json<>& config,
         bool& necessary_parameter_set);

--- a/include/anira/utils/Logger.h
+++ b/include/anira/utils/Logger.h
@@ -3,7 +3,7 @@
 
 #include <iostream>
 
-inline bool isLoggingEnabled() {
+inline bool is_logging_enabled() {
 #ifdef ENABLE_LOGGING
     return true;
 #else
@@ -12,8 +12,8 @@ inline bool isLoggingEnabled() {
 }
 
 #define LOG_INFO \
-    if (isLoggingEnabled()) (std::cout)
+    if (is_logging_enabled()) (std::cout)
 #define LOG_ERROR \
-    if (isLoggingEnabled()) (std::cerr)
+    if (is_logging_enabled()) (std::cerr)
 
 #endif  // ANIRA_LOGGER_H

--- a/include/anira/utils/MemoryBlock.h
+++ b/include/anira/utils/MemoryBlock.h
@@ -49,11 +49,13 @@ public:
      *       using appropriate initialization after construction.
      */
     MemoryBlock(std::size_t size = 0) : m_size(size) {
+        // A size of 0 is a valid empty block; malloc(0) is intentional here.
+        // NOLINTNEXTLINE(clang-analyzer-optin.portability.UnixAPI)
         void* data = malloc(sizeof(T) * m_size);
         if (data != nullptr) {
             m_data = (T*)data;
         } else {
-            LOG_ERROR << "Failed to allocate memory!" << std::endl;
+            LOG_ERROR << "Failed to allocate memory!" << '\n';
         }
     }
 
@@ -79,7 +81,7 @@ public:
             m_data = (T*)data;
             std::memcpy(m_data, other.m_data, sizeof(T) * m_size);
         } else {
-            LOG_ERROR << "Failed to allocate memory!" << std::endl;
+            LOG_ERROR << "Failed to allocate memory!" << '\n';
         }
     }
 
@@ -101,7 +103,7 @@ public:
                 m_data = (T*)data;
                 std::memcpy(m_data, other.m_data, sizeof(T) * m_size);
             } else {
-                LOG_ERROR << "Failed to allocate memory!" << std::endl;
+                LOG_ERROR << "Failed to allocate memory!" << '\n';
             }
         }
         return *this;
@@ -209,13 +211,15 @@ public:
             data = realloc(m_data, sizeof(T) * size);
         } else {
             free(m_data);
+            // A size of 0 is a valid empty block; malloc(0) is intentional here.
+            // NOLINTNEXTLINE(clang-analyzer-optin.portability.UnixAPI)
             data = malloc(sizeof(T) * size);
         }
 
         if (data != nullptr) {
             m_data = (T*)data;
         } else {
-            LOG_ERROR << "Failed to reallocate memory!" << std::endl;
+            LOG_ERROR << "Failed to reallocate memory!" << '\n';
         }
     }
 
@@ -229,7 +233,9 @@ public:
      * @note This operation sets all bytes to zero, which may not be appropriate
      *       for all data types (e.g., types with non-trivial constructors).
      */
-    void clear() { std::memset(m_data, 0, sizeof(T) * m_size); }
+    void clear() {
+        if (m_data != nullptr) { std::memset(m_data, 0, sizeof(T) * m_size); }
+    }
 
     /**
      * @brief Swaps data with another memory block without copying (for trivially copyable types)
@@ -248,13 +254,15 @@ public:
      * @note Both blocks must have identical sizes for the swap to succeed.
      *       This function is only available for trivially copyable types.
      */
-    template <typename U = T, std::enable_if_t<std::is_trivially_copyable_v<U>, bool> = true>
-    void swap_data(MemoryBlock& other) {
+    template <typename U = T>
+    void swap_data(MemoryBlock& other)
+        requires(std::is_trivially_copyable_v<U>)
+    {
         if (this != &other) {
             if (m_size == other.m_size) {
                 std::swap(m_data, other.m_data);
             } else {
-                LOG_ERROR << "Cannot swap data with different sizes!" << std::endl;
+                LOG_ERROR << "Cannot swap data with different sizes!" << '\n';
             }
         }
     }
@@ -275,7 +283,7 @@ public:
         if (m_size == size) {
             std::swap(m_data, data);
         } else {
-            LOG_ERROR << "Cannot swap data with different sizes!" << std::endl;
+            LOG_ERROR << "Cannot swap data with different sizes!" << '\n';
         }
     }
 

--- a/include/anira/utils/helperFunctions.h
+++ b/include/anira/utils/helperFunctions.h
@@ -56,11 +56,11 @@ static double calculate_percentile(const std::vector<double>& v, double percenti
 
     // Sort the data in ascending order
     std::vector<double> sorted_data = v;
-    std::sort(sorted_data.begin(), sorted_data.end());
+    std::ranges::sort(sorted_data);
 
     // Calculate the index for the 99th percentile
-    size_t n = sorted_data.size();
-    size_t percentile_index = (size_t)(percentile * (n - 1));
+    size_t const n = sorted_data.size();
+    auto const percentile_index = static_cast<size_t>(percentile * static_cast<double>(n - 1));
 
     // Check if the index is an integer
     if (percentile_index == static_cast<size_t>(percentile_index)) {
@@ -68,9 +68,9 @@ static double calculate_percentile(const std::vector<double>& v, double percenti
         return sorted_data[static_cast<size_t>(percentile_index)];
     } else {
         // Interpolate between the two nearest values
-        size_t lower_index = static_cast<size_t>(percentile_index);
-        size_t upper_index = lower_index + 1;
-        double fraction = percentile_index - lower_index;
+        auto const lower_index = static_cast<size_t>(percentile_index);
+        size_t const upper_index = lower_index + 1;
+        auto const fraction = static_cast<double>(percentile_index - lower_index);
         return (1.0 - fraction) * sorted_data[lower_index] + fraction * sorted_data[upper_index];
     }
 }
@@ -87,7 +87,7 @@ static double calculate_percentile(const std::vector<double>& v, double percenti
 static void fill_buffer(BufferF& buffer) {
     for (size_t i = 0; i < buffer.get_num_channels(); i++) {
         for (size_t j = 0; j < buffer.get_num_samples(); j++) {
-            float new_val = random_sample();
+            float const new_val = random_sample();
             buffer.set_sample(i, j, new_val);
         }
     }
@@ -121,38 +121,30 @@ static void push_buffer_to_ringbuffer(BufferF const& buffer, RingBuffer& ringbuf
 }
 
 /**
- * @brief Lambda function to calculate the minimum value in a dataset
+ * @brief Calculates the minimum value in a dataset
  *
- * A constant lambda expression that finds and returns the smallest value
- * in a vector of double values. This function uses std::min_element for
- * efficient minimum value computation.
+ * Finds and returns the smallest value in a vector of double values, using
+ * std::ranges::min_element for efficient minimum value computation.
  *
  * @param v Vector of double values to find the minimum from
  * @return The minimum value in the vector
- *
- * @note This is a lambda function stored as a const auto variable for
- *       convenient reuse throughout the codebase.
  */
-const auto calculate_min = [](const std::vector<double>& v) -> double {
-    return *(std::min_element(std::begin(v), std::end(v)));
-};
+inline double calculate_min(const std::vector<double>& v) {
+    return *(std::ranges::min_element(v));
+}
 
 /**
- * @brief Lambda function to calculate the maximum value in a dataset
+ * @brief Calculates the maximum value in a dataset
  *
- * A constant lambda expression that finds and returns the largest value
- * in a vector of double values. This function uses std::max_element for
- * efficient maximum value computation.
+ * Finds and returns the largest value in a vector of double values, using
+ * std::ranges::max_element for efficient maximum value computation.
  *
  * @param v Vector of double values to find the maximum from
  * @return The maximum value in the vector
- *
- * @note This is a lambda function stored as a const auto variable for
- *       convenient reuse throughout the codebase.
  */
-const auto calculate_max = [](const std::vector<double>& v) -> double {
-    return *(std::max_element(std::begin(v), std::end(v)));
-};
+inline double calculate_max(const std::vector<double>& v) {
+    return *(std::ranges::max_element(v));
+}
 
 }  // namespace anira
 

--- a/src/InferenceConfig.cpp
+++ b/src/InferenceConfig.cpp
@@ -1,7 +1,14 @@
 #include <anira/InferenceConfig.h>
+#include <anira/utils/InferenceBackend.h>
 #include <anira/utils/Logger.h>
 
+#include <cassert>
+#include <cstdlib>
 #include <cstring>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
 
 namespace anira {
 
@@ -13,17 +20,17 @@ InferenceConfig::InferenceConfig(std::vector<ModelData> model_data,
                                  bool session_exclusive_processor,
                                  float blocking_ratio,
                                  unsigned int num_parallel_processors)
-    : m_model_data(model_data)
-    , m_tensor_shape(tensor_shape)
+    : m_model_data(std::move(std::move(model_data)))
+    , m_tensor_shape(std::move(std::move(tensor_shape)))
     , m_max_inference_time(max_inference_time)
-    , m_processing_spec(processing_spec)
+    , m_processing_spec(std::move(std::move(processing_spec)))
     , m_warm_up(warm_up)
     , m_session_exclusive_processor(session_exclusive_processor)
     , m_blocking_ratio(blocking_ratio)
     , m_num_parallel_processors(num_parallel_processors) {
     if (m_max_inference_time <= 0.f) {
         LOG_ERROR << "Invalid max_inference_time: " << m_max_inference_time
-                  << ". It must be greater than 0." << std::endl;
+                  << ". It must be greater than 0." << '\n';
         throw std::invalid_argument("max_inference_time must be greater than 0.");
     }
 
@@ -33,15 +40,13 @@ InferenceConfig::InferenceConfig(std::vector<ModelData> model_data,
     if (m_num_parallel_processors < 1) {
         m_num_parallel_processors = 1;
         LOG_INFO << "[WARNING] Number of parellel processors must be at least 1. Setting to 1."
-                 << std::endl;
+                 << '\n';
     }
 }
 
 std::string InferenceConfig::get_model_path(InferenceBackend backend) {
-    for (int i = 0; i < m_model_data.size(); ++i) {
-        if (m_model_data[i].m_backend == backend) {
-            return std::string((char*)m_model_data[i].m_data, m_model_data[i].m_size);
-        }
+    for (auto& i : m_model_data) {
+        if (i.m_backend == backend) { return {(char*)i.m_data, i.m_size}; }
     }
     assert((false && "No model path found for backend."));
     return "";
@@ -191,13 +196,13 @@ void InferenceConfig::set_internal_model_latency(
 }
 
 void InferenceConfig::set_model_path(const std::string& model_path, InferenceBackend backend) {
-    for (int i = 0; i < m_model_data.size(); ++i) {
-        if (m_model_data[i].m_backend == backend) {
-            if (!m_model_data[i].m_is_binary) {
-                free(m_model_data[i].m_data);
-                m_model_data[i].m_data = malloc(model_path.size() * sizeof(char));
-                std::memcpy(m_model_data[i].m_data, model_path.c_str(), model_path.size());
-                m_model_data[i].m_size = model_path.size();
+    for (auto& i : m_model_data) {
+        if (i.m_backend == backend) {
+            if (!i.m_is_binary) {
+                free(i.m_data);
+                i.m_data = malloc(model_path.size() * sizeof(char));
+                std::memcpy(i.m_data, model_path.c_str(), model_path.size());
+                i.m_size = model_path.size();
             }
             return;
         }
@@ -213,7 +218,7 @@ const TensorShape& InferenceConfig::get_tensor_shape(InferenceBackend backend) c
         if (shape.is_universal()) { return shape; }
     }
     LOG_ERROR << "No tensor shape found for backend: " << static_cast<int>(backend)
-              << ". Returning the first tensor shape." << std::endl;
+              << ". Returning the first tensor shape." << '\n';
     return m_tensor_shape[0];  // Fallback to the first tensor shape
 }
 
@@ -229,11 +234,11 @@ void InferenceConfig::clear_processing_spec() {
 
 void InferenceConfig::update_processing_spec() {
     assert((m_tensor_shape.size() > 0 && "At least one tensor shape must be provided."));
-    for (size_t i = 0; i < m_model_data.size(); ++i) {
+    for (auto& i : m_model_data) {
         bool success = false;
-        for (size_t j = 0; j < m_tensor_shape.size(); ++j) {
-            if (!m_tensor_shape[j].is_universal()) {
-                if (m_model_data[i].m_backend == m_tensor_shape[j].m_backend) {
+        for (auto& j : m_tensor_shape) {
+            if (!j.is_universal()) {
+                if (i.m_backend == j.m_backend) {
                     success = true;
                     break;
                 }
@@ -243,7 +248,7 @@ void InferenceConfig::update_processing_spec() {
             for (size_t j = 0; j < m_tensor_shape.size(); ++j) {
                 if (m_tensor_shape[j].is_universal()) {
                     TensorShape tensor_shape = m_tensor_shape[j];
-                    tensor_shape.m_backend = m_model_data[i].m_backend;
+                    tensor_shape.m_backend = i.m_backend;
                     m_tensor_shape.push_back(tensor_shape);
                     break;
                 }
@@ -261,20 +266,20 @@ void InferenceConfig::update_processing_spec() {
         if (shape.m_tensor_input_shape.size() < 1) {
             LOG_ERROR << "No input shape provided for backend: "
                       << static_cast<int>(shape.m_backend)
-                      << ". At least one input shape must be provided." << std::endl;
+                      << ". At least one input shape must be provided." << '\n';
             throw std::invalid_argument("No input shape provided.");
         }
         if (shape.m_tensor_output_shape.size() < 1) {
             LOG_ERROR << "No output shape provided for backend: "
                       << static_cast<int>(shape.m_backend)
-                      << ". At least one output shape must be provided." << std::endl;
+                      << ". At least one output shape must be provided." << '\n';
             throw std::invalid_argument("No output shape provided.");
         }
         for (int j = 0; j < shape.m_tensor_input_shape.size(); ++j) {
             for (auto& dim : shape.m_tensor_input_shape[j]) {
                 if (dim < 1) {
                     LOG_ERROR << "Invalid dimension in input shape: " << dim
-                              << ". Input dimensions must be positive." << std::endl;
+                              << ". Input dimensions must be positive." << '\n';
                     throw std::invalid_argument("Invalid dimension in input shape.");
                 }
                 input_size[j] *= (size_t)dim;
@@ -284,7 +289,7 @@ void InferenceConfig::update_processing_spec() {
             for (auto& dim : shape.m_tensor_output_shape[j]) {
                 if (dim < 1) {
                     LOG_ERROR << "Invalid dimension in output shape: " << dim
-                              << ". Output dimensions must be positive." << std::endl;
+                              << ". Output dimensions must be positive." << '\n';
                     throw std::invalid_argument("Invalid dimension in output shape.");
                 }
                 output_size[j] *= (size_t)dim;
@@ -347,13 +352,13 @@ void InferenceConfig::update_processing_spec() {
             if (m_processing_spec.m_tensor_input_size != input_size) {
                 LOG_ERROR << "Input size mismatch for backend: "
                           << static_cast<int>(shape.m_backend)
-                          << ". All backends must have the same input size." << std::endl;
+                          << ". All backends must have the same input size." << '\n';
                 throw std::invalid_argument("Input size mismatch.");
             }
             if (m_processing_spec.m_tensor_output_size != output_size) {
                 LOG_ERROR << "Output size mismatch for backend: "
                           << static_cast<int>(shape.m_backend)
-                          << ". All backends must have the same output size." << std::endl;
+                          << ". All backends must have the same output size." << '\n';
                 throw std::invalid_argument("Output size mismatch.");
             }
         }
@@ -362,39 +367,39 @@ void InferenceConfig::update_processing_spec() {
         m_processing_spec.m_tensor_input_size.size()) {
         LOG_ERROR
             << "Preprocess input channels size mismatch. Must match the number of input tensors."
-            << std::endl;
+            << '\n';
         throw std::invalid_argument("Preprocess input channels size mismatch.");
     }
     if (m_processing_spec.m_postprocess_output_channels.size() !=
         m_processing_spec.m_tensor_output_size.size()) {
         LOG_ERROR
             << "Postprocess output channels size mismatch. Must match the number of output tensors."
-            << std::endl;
+            << '\n';
         throw std::invalid_argument("Postprocess output channels size mismatch.");
     }
     if (m_processing_spec.m_preprocess_input_size.size() !=
         m_processing_spec.m_tensor_input_size.size()) {
         LOG_ERROR << "Preprocess input size mismatch. Must match the number of input tensors."
-                  << std::endl;
+                  << '\n';
         throw std::invalid_argument("Preprocess input size mismatch.");
     }
     if (m_processing_spec.m_postprocess_output_size.size() !=
         m_processing_spec.m_tensor_output_size.size()) {
         LOG_ERROR << "Postprocess output size mismatch. Must match the number of output tensors."
-                  << std::endl;
+                  << '\n';
         throw std::invalid_argument("Postprocess output size mismatch.");
     }
     if (m_processing_spec.m_internal_model_latency.size() !=
         m_processing_spec.m_tensor_output_size.size()) {
         LOG_ERROR << "Internal latency size mismatch. Must match the number of output tensors."
-                  << std::endl;
+                  << '\n';
         throw std::invalid_argument("Internal latency size mismatch.");
     }
     for (size_t i = 0; i < m_processing_spec.m_tensor_input_size.size(); ++i) {
         if (m_processing_spec.m_preprocess_input_size[i] == 0) {
             if (m_processing_spec.m_preprocess_input_channels[i] != 1) {
                 LOG_ERROR << "For non-streamable tensors (preprocess_input_size[" << i
-                          << "] == 0), the number of channels must be 1." << std::endl;
+                          << "] == 0), the number of channels must be 1." << '\n';
                 throw std::invalid_argument(
                     "Invalid number of channels for non-streamable tensor.");
             }
@@ -404,7 +409,7 @@ void InferenceConfig::update_processing_spec() {
         if (m_processing_spec.m_postprocess_output_size[i] == 0) {
             if (m_processing_spec.m_postprocess_output_channels[i] != 1) {
                 LOG_ERROR << "For non-streamable tensors (postprocess_output_size[" << i
-                          << "] == 0), the number of channels must be 1." << std::endl;
+                          << "] == 0), the number of channels must be 1." << '\n';
                 throw std::invalid_argument(
                     "Invalid number of channels for non-streamable tensor.");
             }

--- a/src/InferenceHandler.cpp
+++ b/src/InferenceHandler.cpp
@@ -1,7 +1,15 @@
+#include <anira/ContextConfig.h>
+#include <anira/InferenceConfig.h>
 #include <anira/InferenceHandler.h>
+#include <anira/PrePostProcessor.h>
+#include <anira/backends/BackendBase.h>
+#include <anira/utils/HostConfig.h>
+#include <anira/utils/InferenceBackend.h>
 
 #include <cassert>
+#include <chrono>
 #include <cstdlib>
+#include <vector>
 
 namespace anira {
 
@@ -24,9 +32,9 @@ InferenceHandler::InferenceHandler(PrePostProcessor& pp_processor,
     if (!m_input_tensor_ptrs || !m_input_tensor_num_samples || !m_output_tensor_ptrs ||
         !m_output_tensor_num_samples) {
         // Clean up on allocation failure
-        free(m_input_tensor_ptrs);
+        free(reinterpret_cast<void*>(m_input_tensor_ptrs));
         free(m_input_tensor_num_samples);
-        free(m_output_tensor_ptrs);
+        free(reinterpret_cast<void*>(m_output_tensor_ptrs));
         free(m_output_tensor_num_samples);
         throw std::bad_alloc();
     }
@@ -52,18 +60,18 @@ InferenceHandler::InferenceHandler(PrePostProcessor& pp_processor,
     if (!m_input_tensor_ptrs || !m_input_tensor_num_samples || !m_output_tensor_ptrs ||
         !m_output_tensor_num_samples) {
         // Clean up on allocation failure
-        free(m_input_tensor_ptrs);
+        free(reinterpret_cast<void*>(m_input_tensor_ptrs));
         free(m_input_tensor_num_samples);
-        free(m_output_tensor_ptrs);
+        free(reinterpret_cast<void*>(m_output_tensor_ptrs));
         free(m_output_tensor_num_samples);
         throw std::bad_alloc();
     }
 }
 
 InferenceHandler::~InferenceHandler() {
-    free(m_input_tensor_ptrs);
+    free(reinterpret_cast<void*>(m_input_tensor_ptrs));
     free(m_input_tensor_num_samples);
-    free(m_output_tensor_ptrs);
+    free(reinterpret_cast<void*>(m_output_tensor_ptrs));
     free(m_output_tensor_num_samples);
 }
 
@@ -114,8 +122,8 @@ size_t InferenceHandler::process(const float* const* input_data,
                                  size_t num_output_samples,
                                  size_t tensor_index) {
     // Get the number of input and output tensors from the inference config
-    size_t num_input_tensors = m_inference_config.get_tensor_input_shape().size();
-    size_t num_output_tensors = m_inference_config.get_tensor_output_shape().size();
+    size_t const num_input_tensors = m_inference_config.get_tensor_input_shape().size();
+    size_t const num_output_tensors = m_inference_config.get_tensor_output_shape().size();
 
     // Set the input and output tensor pointers and sample counts
     if (tensor_index < num_input_tensors) {

--- a/src/PrePostProcessor.cpp
+++ b/src/PrePostProcessor.cpp
@@ -1,4 +1,13 @@
+#include <anira/InferenceConfig.h>
 #include <anira/PrePostProcessor.h>
+#include <anira/utils/Buffer.h>
+#include <anira/utils/InferenceBackend.h>
+#include <anira/utils/RingBuffer.h>
+
+#include <cassert>
+#include <cstddef>
+#include <utility>
+#include <vector>
 
 namespace anira {
 
@@ -88,11 +97,11 @@ void PrePostProcessor::pop_samples_from_buffer(RingBuffer& input,
                                                size_t num_new_samples,
                                                size_t num_old_samples,
                                                size_t offset) {
-    int num_total_samples = num_new_samples + num_old_samples;
+    int const num_total_samples = static_cast<int>(num_new_samples + num_old_samples);
     for (size_t i = 0; i < input.get_num_channels(); i++) {
         // int j is important to be signed, because it is used in the condition j >= 0
         for (int j = num_total_samples - 1; j >= 0; j--) {
-            if (j >= num_old_samples) {
+            if (std::cmp_greater_equal(j, num_old_samples)) {
                 output.set_sample(0,
                                   (size_t)(num_total_samples - j + num_old_samples - 1) + offset,
                                   input.pop_sample(i));

--- a/src/backends/BackendBase.cpp
+++ b/src/backends/BackendBase.cpp
@@ -1,4 +1,10 @@
+#include <anira/InferenceConfig.h>
 #include <anira/backends/BackendBase.h>
+#include <anira/utils/Buffer.h>
+
+#include <cstddef>
+#include <memory>
+#include <vector>
 
 namespace anira {
 
@@ -7,11 +13,14 @@ BackendBase::BackendBase(InferenceConfig& inference_config)
 
 void BackendBase::prepare() {}
 
+// The session parameter is passed by value to match the virtual signature declared in the header
+// (BackendBase.h), which is out of scope to change here.
 void BackendBase::process(std::vector<BufferF>& input,
                           std::vector<BufferF>& output,
-                          [[maybe_unused]] std::shared_ptr<SessionElement> session) {
+                          [[maybe_unused]] std::shared_ptr<SessionElement>
+                              session) {  // NOLINT(performance-unnecessary-value-param)
     for (size_t i = 0; i < input.size(); ++i) {
-        bool equal_channels = input[i].get_num_channels() == output[i].get_num_channels();
+        bool const equal_channels = input[i].get_num_channels() == output[i].get_num_channels();
         auto sample_diff = input[i].get_num_samples() - output[i].get_num_samples();
         if (equal_channels && sample_diff == 0) {
             for (int channel = 0; channel < input[i].get_num_channels(); ++channel) {

--- a/src/backends/LibTorchProcessor.cpp
+++ b/src/backends/LibTorchProcessor.cpp
@@ -1,5 +1,19 @@
+#include <anira/InferenceConfig.h>
+#include <anira/backends/BackendBase.h>
 #include <anira/backends/LibTorchProcessor.h>
+#include <anira/scheduler/SessionElement.h>
+#include <anira/utils/Buffer.h>
+#include <anira/utils/InferenceBackend.h>
 #include <anira/utils/Logger.h>
+#include <c10/util/Exception.h>
+#include <torch/csrc/autograd/generated/variable_factories.h>
+#include <torch/csrc/jit/serialization/import.h>
+#include <torch/utils.h>
+
+#include <cstddef>
+#include <memory>
+#include <sstream>
+#include <vector>
 
 namespace anira {
 
@@ -12,7 +26,7 @@ LibtorchProcessor::LibtorchProcessor(InferenceConfig& inference_config)
     }
 }
 
-LibtorchProcessor::~LibtorchProcessor() {}
+LibtorchProcessor::~LibtorchProcessor() = default;
 
 void LibtorchProcessor::prepare() {
     for (auto& instance : m_instances) { instance->prepare(); }
@@ -45,7 +59,7 @@ LibtorchProcessor::Instance::Instance(InferenceConfig& inference_config)
             m_module = torch::jit::load(stream);
         } catch (const c10::Error& e) {
             LOG_ERROR << "[ERROR] error loading the model\n";
-            LOG_ERROR << e.what() << std::endl;
+            LOG_ERROR << e.what() << '\n';
         }
     } else {
         try {
@@ -53,7 +67,7 @@ LibtorchProcessor::Instance::Instance(InferenceConfig& inference_config)
                 m_inference_config.get_model_path(anira::InferenceBackend::LIBTORCH));
         } catch (const c10::Error& e) {
             LOG_ERROR << "[ERROR] error loading the model\n";
-            LOG_ERROR << e.what() << std::endl;
+            LOG_ERROR << e.what() << '\n';
         }
     }
     m_module.eval();
@@ -71,7 +85,7 @@ LibtorchProcessor::Instance::Instance(InferenceConfig& inference_config)
     }
 
     // No gradient calculation for inference
-    torch::NoGradGuard no_grad;
+    torch::NoGradGuard const no_grad;
     for (size_t i = 0; i < m_inference_config.m_warm_up; i++) {
         if (!m_inference_config.get_model_function(InferenceBackend::LIBTORCH).empty()) {
             auto method = m_module.get_method(
@@ -92,9 +106,9 @@ void LibtorchProcessor::Instance::prepare() {
 
 void LibtorchProcessor::Instance::process(std::vector<BufferF>& input,
                                           std::vector<BufferF>& output,
-                                          std::shared_ptr<SessionElement> session) {
+                                          const std::shared_ptr<SessionElement>&) {
     // No gradient calculation for inference
-    torch::NoGradGuard no_grad;
+    torch::NoGradGuard const no_grad;
     for (size_t i = 0; i < m_inference_config.get_tensor_input_shape().size(); i++) {
         m_input_data[i].swap_data(input[i].get_memory_block());
         input[i].reset_channel_ptr();

--- a/src/backends/OnnxRuntimeProcessor.cpp
+++ b/src/backends/OnnxRuntimeProcessor.cpp
@@ -1,5 +1,18 @@
+#include <anira/InferenceConfig.h>
+#include <anira/backends/BackendBase.h>
 #include <anira/backends/OnnxRuntimeProcessor.h>
+#include <anira/scheduler/SessionElement.h>
+#include <anira/utils/Buffer.h>
+#include <anira/utils/InferenceBackend.h>
 #include <anira/utils/Logger.h>
+#include <onnxruntime_c_api.h>
+#include <onnxruntime_cxx_api.h>
+
+#include <cassert>
+#include <cstddef>
+#include <memory>
+#include <string>
+#include <vector>
 
 namespace anira {
 
@@ -10,7 +23,7 @@ OnnxRuntimeProcessor::OnnxRuntimeProcessor(InferenceConfig& inference_config)
     }
 }
 
-OnnxRuntimeProcessor::~OnnxRuntimeProcessor() {}
+OnnxRuntimeProcessor::~OnnxRuntimeProcessor() = default;
 
 void OnnxRuntimeProcessor::prepare() {
     for (auto& instance : m_instances) { instance->prepare(); }
@@ -73,7 +86,8 @@ OnnxRuntimeProcessor::Instance::Instance(InferenceConfig& inference_config)
             m_inference_config.get_model_path(anira::InferenceBackend::ONNX);
         std::wstring modelpath = std::wstring(modelpath_str.begin(), modelpath_str.end());
 #else
-        std::string modelpath = m_inference_config.get_model_path(anira::InferenceBackend::ONNX);
+        std::string const modelpath =
+            m_inference_config.get_model_path(anira::InferenceBackend::ONNX);
 #endif
         m_session = std::make_unique<Ort::Session>(m_env, modelpath.c_str(), m_session_options);
     }
@@ -112,7 +126,7 @@ OnnxRuntimeProcessor::Instance::Instance(InferenceConfig& inference_config)
                                        m_input_names.size(),
                                        m_output_names.data(),
                                        m_output_names.size());
-        } catch (Ort::Exception& e) { LOG_ERROR << e.what() << std::endl; }
+        } catch (Ort::Exception& e) { LOG_ERROR << e.what() << '\n'; }
     }
 }
 
@@ -128,7 +142,7 @@ void OnnxRuntimeProcessor::Instance::prepare() {
 
 void OnnxRuntimeProcessor::Instance::process(std::vector<BufferF>& input,
                                              std::vector<BufferF>& output,
-                                             std::shared_ptr<SessionElement> session) {
+                                             const std::shared_ptr<SessionElement>&) {
     for (size_t i = 0; i < m_inference_config.get_tensor_input_shape().size(); i++) {
         m_inputs[i] = Ort::Value::CreateTensor<float>(
             m_memory_info,
@@ -145,7 +159,7 @@ void OnnxRuntimeProcessor::Instance::process(std::vector<BufferF>& input,
                                    m_input_names.size(),
                                    m_output_names.data(),
                                    m_output_names.size());
-    } catch (Ort::Exception& e) { LOG_ERROR << e.what() << std::endl; }
+    } catch (Ort::Exception& e) { LOG_ERROR << e.what() << '\n'; }
 
     for (size_t i = 0; i < m_outputs.size(); i++) {
         const auto output_read_ptr = m_outputs[i].GetTensorMutableData<float>();

--- a/src/backends/TFLiteProcessor.cpp
+++ b/src/backends/TFLiteProcessor.cpp
@@ -1,4 +1,17 @@
+#include <anira/InferenceConfig.h>
+#include <anira/backends/BackendBase.h>
 #include <anira/backends/TFLiteProcessor.h>
+#include <anira/scheduler/SessionElement.h>
+#include <anira/utils/Buffer.h>
+#include <anira/utils/InferenceBackend.h>
+#include <tensorflow/lite/core/c/c_api.h>
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
 
 #ifdef _WIN32
 #include <comdef.h>
@@ -13,7 +26,7 @@ TFLiteProcessor::TFLiteProcessor(InferenceConfig& inference_config)
     }
 }
 
-TFLiteProcessor::~TFLiteProcessor() {}
+TFLiteProcessor::~TFLiteProcessor() = default;
 
 void TFLiteProcessor::prepare() {
     for (auto& instance : m_instances) { instance->prepare(); }
@@ -41,7 +54,8 @@ TFLiteProcessor::Instance::Instance(InferenceConfig& inference_config)
         assert(model_data && "Model data not found for binary model!");
         m_model = TfLiteModelCreate(model_data->m_data, model_data->m_size);
     } else {
-        std::string modelpath = m_inference_config.get_model_path(anira::InferenceBackend::TFLITE);
+        std::string const modelpath =
+            m_inference_config.get_model_path(anira::InferenceBackend::TFLITE);
         m_model = TfLiteModelCreateFromFile(modelpath.c_str());
     }
 
@@ -53,13 +67,12 @@ TFLiteProcessor::Instance::Instance(InferenceConfig& inference_config)
     // tensors obviously
     for (size_t i = 0; i < m_inference_config.get_tensor_input_shape().size(); i++) {
         std::vector<int> input_shape;
-        std::vector<int64_t> input_shape64 =
+        std::vector<int64_t> const input_shape64 =
             m_inference_config.get_tensor_input_shape(anira::InferenceBackend::TFLITE)[i];
-        for (size_t j = 0; j < input_shape64.size(); j++) {
-            input_shape.push_back((int)input_shape64[j]);
-        }
+        input_shape.reserve(input_shape64.size());
+        for (long j : input_shape64) { input_shape.push_back((int)j); }
         TfLiteInterpreterResizeInputTensor(m_interpreter,
-                                           i,
+                                           static_cast<int32_t>(i),
                                            input_shape.data(),
                                            static_cast<int32_t>(input_shape.size()));
     }
@@ -70,12 +83,12 @@ TFLiteProcessor::Instance::Instance(InferenceConfig& inference_config)
     m_input_data.resize(m_inference_config.get_tensor_input_shape().size());
     for (size_t i = 0; i < m_inference_config.get_tensor_input_shape().size(); i++) {
         m_input_data[i].resize(m_inference_config.get_tensor_input_size()[i]);
-        m_inputs[i] = TfLiteInterpreterGetInputTensor(m_interpreter, i);
+        m_inputs[i] = TfLiteInterpreterGetInputTensor(m_interpreter, static_cast<int32_t>(i));
     }
 
     m_outputs.resize(m_inference_config.get_tensor_output_shape().size());
     for (size_t i = 0; i < m_inference_config.get_tensor_output_shape().size(); i++) {
-        m_outputs[i] = TfLiteInterpreterGetOutputTensor(m_interpreter, i);
+        m_outputs[i] = TfLiteInterpreterGetOutputTensor(m_interpreter, static_cast<int32_t>(i));
     }
 
     for (size_t i = 0; i < m_inference_config.m_warm_up; i++) {
@@ -97,7 +110,7 @@ void TFLiteProcessor::Instance::prepare() {
 
 void TFLiteProcessor::Instance::process(std::vector<BufferF>& input,
                                         std::vector<BufferF>& output,
-                                        std::shared_ptr<SessionElement> session) {
+                                        const std::shared_ptr<SessionElement>&) {
     for (size_t i = 0; i < m_inference_config.get_tensor_input_shape().size(); i++) {
         m_input_data[i].swap_data(input[i].get_memory_block());
         input[i].reset_channel_ptr();
@@ -112,7 +125,7 @@ void TFLiteProcessor::Instance::process(std::vector<BufferF>& input,
 
     // We need to copy the data because we cannot access the data pointer ref of the tensor directly
     for (size_t i = 0; i < m_inference_config.get_tensor_output_shape().size(); i++) {
-        float* output_read_ptr = (float*)TfLiteTensorData(m_outputs[i]);
+        auto* output_read_ptr = (float*)TfLiteTensorData(m_outputs[i]);
         for (size_t j = 0; j < m_inference_config.get_tensor_output_size()[i]; j++) {
             output[i].get_memory_block()[j] = output_read_ptr[j];
         }

--- a/src/benchmark/ProcessBlockFixture.cpp
+++ b/src/benchmark/ProcessBlockFixture.cpp
@@ -1,7 +1,20 @@
+#include <anira/InferenceConfig.h>
 #include <anira/benchmark/ProcessBlockFixture.h>
+#include <anira/utils/HostConfig.h>
+#include <anira/utils/InferenceBackend.h>
+#include <anira/utils/helperFunctions.h>
+#include <benchmark/benchmark.h>
 
-namespace anira {
-namespace benchmark {
+#include <chrono>
+#include <cstddef>
+#include <iomanip>
+#include <ios>
+#include <iostream>
+#include <ratio>
+#include <string>
+#include <thread>
+
+namespace anira::benchmark {
 
 ProcessBlockFixture::ProcessBlockFixture() {
     // A new instance of ProcessBlockFixture is created for each benchmark that has been defined and
@@ -10,10 +23,10 @@ ProcessBlockFixture::ProcessBlockFixture() {
     m_repetition = 0;
 }
 
-ProcessBlockFixture::~ProcessBlockFixture() {}
+ProcessBlockFixture::~ProcessBlockFixture() = default;
 
 void ProcessBlockFixture::initialize_iteration() {
-    m_prev_num_received_samples = m_inference_handler->get_available_samples(0);
+    m_prev_num_received_samples = static_cast<int>(m_inference_handler->get_available_samples(0));
 }
 
 void ProcessBlockFixture::initialize_repetition(const InferenceConfig& inference_config,
@@ -67,17 +80,17 @@ void ProcessBlockFixture::initialize_repetition(const InferenceConfig& inference
         if (m_host_config != host_config) { m_host_config = host_config; }
         std::cout << "\n---------------------------------------------------------------------------"
                      "-------------------------------------------------------------"
-                  << std::endl;
+                  << '\n';
         std::cout << "Model: " << m_model_name << " | Backend: " << m_inference_backend_name
                   << " | Host Sample Rate: " << std::fixed << std::setprecision(0)
                   << m_host_config.m_sample_rate
                   << " Hz | Host Buffer Size: " << m_host_config.m_buffer_size << " = "
                   << std::fixed << std::setprecision(4)
                   << (float)m_host_config.m_buffer_size * 1000.f / m_host_config.m_sample_rate
-                  << " ms" << std::endl;
+                  << " ms" << '\n';
         std::cout << "-----------------------------------------------------------------------------"
                      "-----------------------------------------------------------\n"
-                  << std::endl;
+                  << '\n';
     }
 }
 
@@ -88,7 +101,7 @@ bool ProcessBlockFixture::buffer_processed() {
 void ProcessBlockFixture::push_random_samples_in_buffer(anira::HostConfig host_config) {
     for (size_t channel = 0; channel < m_inference_config.get_preprocess_input_channels()[0];
          channel++) {
-        for (size_t sample = 0; sample < host_config.m_buffer_size; sample++) {
+        for (size_t sample = 0; sample < static_cast<size_t>(host_config.m_buffer_size); sample++) {
             m_buffer->set_sample(channel, sample, random_sample());
         }
     }
@@ -117,7 +130,7 @@ void ProcessBlockFixture::interation_step(const std::chrono::steady_clock::time_
     std::cout << "SingleIteration/" << state.name() << "/" << m_model_name << "/"
               << m_inference_backend_name << "/" << state.range(0) << "/iteration:" << m_iteration
               << "/repetition:" << m_repetition << "\t\t\t" << std::fixed << std::setprecision(4)
-              << elapsed_time_ms.count() << " ms" << std::endl;
+              << elapsed_time_ms.count() << " ms" << '\n';
     m_iteration++;
 }
 
@@ -125,19 +138,18 @@ void ProcessBlockFixture::repetition_step() {
     m_repetition += 1;
     std::cout << "\n-------------------------------------------------------------------------------"
                  "---------------------------------------------------------\n"
-              << std::endl;
+              << '\n';
 }
 
 void ProcessBlockFixture::SetUp(const ::benchmark::State& state) {
     if (m_buffer_size != (int)state.range(0)) { m_buffer_size = (int)state.range(0); }
 }
 
-void ProcessBlockFixture::TearDown(const ::benchmark::State& state) {
+void ProcessBlockFixture::TearDown(const ::benchmark::State&) {
     m_buffer.reset();
     m_inference_handler.reset();
 
     if (m_sleep_after_repetition) { std::this_thread::sleep_for(m_runtime_last_repetition); }
 }
 
-}  // namespace benchmark
-}  // namespace anira
+}  // namespace anira::benchmark

--- a/src/scheduler/Context.cpp
+++ b/src/scheduler/Context.cpp
@@ -1,5 +1,26 @@
+#include <anira/ContextConfig.h>
+#include <anira/InferenceConfig.h>
+#include <anira/PrePostProcessor.h>
+#include <anira/backends/BackendBase.h>
+#include <anira/backends/LibTorchProcessor.h>
+#include <anira/backends/OnnxRuntimeProcessor.h>
+#include <anira/backends/TFLiteProcessor.h>
 #include <anira/scheduler/Context.h>
+#include <anira/scheduler/InferenceThread.h>
+#include <anira/scheduler/SessionElement.h>
+#include <anira/utils/HostConfig.h>
+#include <anira/utils/InferenceBackend.h>
 #include <anira/utils/Logger.h>
+#include <concurrentqueue.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <thread>
+#include <utility>
+#include <vector>
 
 namespace anira {
 
@@ -10,19 +31,16 @@ Context::Context(const ContextConfig& context_config) {
     }
 }
 
-Context::~Context() {}
-
 std::shared_ptr<Context> Context::get_instance(const ContextConfig& context_config) {
     if (m_context == nullptr) {
         m_context = std::make_shared<Context>(context_config);
-        LOG_INFO << "[INFO] Anira version: " << m_context->m_context_config.m_anira_version
-                 << std::endl;
+        LOG_INFO << "[INFO] Anira version: " << m_context->m_context_config.m_anira_version << '\n';
     } else {
         // TODO: Better error handling
         if (m_context->m_context_config.m_anira_version != context_config.m_anira_version) {}
         if (m_context->m_context_config.m_enabled_backends != context_config.m_enabled_backends) {
             LOG_ERROR << "[ERROR] Context already initialized with different backends enabled!"
-                      << std::endl;
+                      << '\n';
         }
         // num_threads == 0 means "I'm opting out of the auto-pool and bringing
         // my own threads via Context::make_inference_thread()" — not "shrink
@@ -48,7 +66,7 @@ int Context::get_available_session_id() {
 }
 
 void Context::new_num_threads(unsigned int new_num_threads) {
-    unsigned int current_num_threads = (unsigned int)m_thread_pool.size();
+    auto const current_num_threads = (unsigned int)m_thread_pool.size();
 
     if (new_num_threads > current_num_threads) {
         for (unsigned int i = current_num_threads; i < new_num_threads; ++i) {
@@ -68,8 +86,8 @@ void Context::new_num_threads(unsigned int new_num_threads) {
 std::shared_ptr<SessionElement> Context::create_session(PrePostProcessor& pp_processor,
                                                         InferenceConfig& inference_config,
                                                         BackendBase* custom_processor) {
-    int session_id = get_available_session_id();
-    if (m_producer_tokens.size() < MAX_NUM_INSTANCES) {
+    int const session_id = get_available_session_id();
+    if (m_producer_tokens.size() < k_max_num_instances) {
         m_producer_tokens.emplace_back(
             std::make_unique<moodycamel::ProducerToken>(m_next_inference));
     }
@@ -79,12 +97,12 @@ std::shared_ptr<SessionElement> Context::create_session(PrePostProcessor& pp_pro
             LOG_INFO << "[WARNING] Session " << session_id
                      << " requested more parallel processors than threads are available in "
                         "Context. Using number of threads as number of parallel processors."
-                     << std::endl;
+                     << '\n';
             inference_config.m_num_parallel_processors = (unsigned int)m_thread_pool.size();
         }
     }
 
-    std::shared_ptr<SessionElement> session =
+    std::shared_ptr<SessionElement> const session =
         std::make_shared<SessionElement>(session_id, pp_processor, inference_config);
 
     if (custom_processor != nullptr) {
@@ -111,7 +129,7 @@ void Context::release_thread_pool() {
     m_thread_pool.clear();
 }
 
-void Context::release_session(std::shared_ptr<SessionElement> session) {
+void Context::release_session(const std::shared_ptr<SessionElement>& session) {
     session->m_initialized.store(false, std::memory_order::release);
 
     drain_inference_queue(session);
@@ -152,21 +170,21 @@ void Context::release_session(std::shared_ptr<SessionElement> session) {
     }
 }
 
-void Context::prepare_session(std::shared_ptr<SessionElement> session,
+void Context::prepare_session(const std::shared_ptr<SessionElement>& session,
                               HostConfig new_config,
                               std::vector<long> custom_latency) {
     session->m_initialized.store(false, std::memory_order::release);
 
     drain_inference_queue(session);
 
-    session->prepare(new_config, custom_latency);
+    session->prepare(new_config, std::move(custom_latency));
 
     start_thread_pool();
 
     session->m_initialized.store(true, std::memory_order::release);
 }
 
-void Context::new_data_submitted(std::shared_ptr<SessionElement> session) {
+void Context::new_data_submitted(const std::shared_ptr<SessionElement>& session) {
     while (true) {
         for (size_t tensor_index = 0;
              tensor_index < session->m_inference_config.get_tensor_input_shape().size();
@@ -183,7 +201,7 @@ void Context::new_data_submitted(std::shared_ptr<SessionElement> session) {
                 }
             }
         }
-        bool success = pre_process(session);
+        bool const success = pre_process(session);
 
         if (!success) {
             for (size_t tensor_index = 0;
@@ -216,13 +234,13 @@ void Context::new_data_submitted(std::shared_ptr<SessionElement> session) {
                 }
             }
             LOG_INFO << "[WARNING] No free inference queue found in session: "
-                     << session->m_session_id << "!" << std::endl;
+                     << session->m_session_id << "!" << '\n';
             return;
         }
     }
 }
 
-void Context::new_data_request(std::shared_ptr<SessionElement> session) {
+void Context::new_data_request(const std::shared_ptr<SessionElement>& session) {
     while (session->m_time_stamps.size() > 0) {
         for (size_t i = 0; i < session->m_inference_queue.size(); ++i) {
             if (session->m_inference_queue[i]->m_time_stamp == session->m_time_stamps.back()) {
@@ -248,7 +266,7 @@ void Context::new_data_request(std::shared_ptr<SessionElement> session) {
     }
 }
 
-void Context::new_data_request(std::shared_ptr<SessionElement> session,
+void Context::new_data_request(const std::shared_ptr<SessionElement>& session,
                                std::chrono::steady_clock::time_point wait_until) {
     while (session->m_time_stamps.size() > 0) {
         for (size_t i = 0; i < session->m_inference_queue.size(); ++i) {
@@ -281,7 +299,7 @@ std::vector<std::shared_ptr<SessionElement>>& Context::get_sessions() {
     return m_sessions;
 }
 
-bool Context::pre_process(std::shared_ptr<SessionElement> session) {
+bool Context::pre_process(const std::shared_ptr<SessionElement>& session) {
     for (size_t i = 0; i < session->m_inference_queue.size(); ++i) {
         if (session->m_inference_queue[i]->m_free.exchange(false)) {
             session->m_pp_processor.pre_process(
@@ -298,16 +316,19 @@ bool Context::pre_process(std::shared_ptr<SessionElement> session) {
                 // released one at a time as each completes.
                 session->enqueue_pending_dispatch(session->m_inference_queue[i]);
                 if (auto next = session->try_acquire_next_dispatch()) {
-                    if (!m_next_inference.try_enqueue(InferenceData{session, next})) {
-                        LOG_ERROR << "[ERROR] Could not enqueue next inference!" << std::endl;
+                    if (!m_next_inference.try_enqueue(
+                            InferenceData{.m_session = session, .m_thread_safe_struct = next})) {
+                        LOG_ERROR << "[ERROR] Could not enqueue next inference!" << '\n';
                         session->release_dispatch();  // retried on the next submission/completion
                     }
                 }
             } else {
-                InferenceData inference_data = {session, session->m_inference_queue[i]};
-                moodycamel::ProducerToken& producer_token = get_producer_token();
+                InferenceData const inference_data = {
+                    .m_session = session,
+                    .m_thread_safe_struct = session->m_inference_queue[i]};
+                moodycamel::ProducerToken const& producer_token = get_producer_token();
                 if (!m_next_inference.try_enqueue(producer_token, inference_data)) {
-                    LOG_ERROR << "[ERROR] Could not enqueue next inference!" << std::endl;
+                    LOG_ERROR << "[ERROR] Could not enqueue next inference!" << '\n';
                     session->m_inference_queue[i]->m_free.exchange(true);
                     session->m_time_stamps.pop_back();
                     return false;
@@ -324,8 +345,9 @@ bool Context::pre_process(std::shared_ptr<SessionElement> session) {
     return false;
 }
 
-void Context::post_process(std::shared_ptr<SessionElement> session,
-                           std::shared_ptr<SessionElement::ThreadSafeStruct> thread_safe_struct) {
+void Context::post_process(
+    const std::shared_ptr<SessionElement>& session,
+    const std::shared_ptr<SessionElement::ThreadSafeStruct>& thread_safe_struct) {
     session->m_pp_processor.post_process(
         thread_safe_struct->m_tensor_output_data,
         session->m_receive_buffer,
@@ -334,15 +356,13 @@ void Context::post_process(std::shared_ptr<SessionElement> session,
 }
 
 void Context::start_thread_pool() {
-    for (size_t i = 0; i < m_thread_pool.size(); ++i) {
-        if (!m_thread_pool[i]->is_running()) { m_thread_pool[i]->start(); }
-        while (!m_thread_pool[i]->is_running()) {
-            std::this_thread::sleep_for(std::chrono::microseconds(50));
-        }
+    for (const auto& i : m_thread_pool) {
+        if (!i->is_running()) { i->start(); }
+        while (!i->is_running()) { std::this_thread::sleep_for(std::chrono::microseconds(50)); }
     }
 }
 
-void Context::drain_inference_queue(std::shared_ptr<SessionElement> session) {
+void Context::drain_inference_queue(const std::shared_ptr<SessionElement>& session) {
     while (session->m_active_inferences.load(std::memory_order::acquire) != 0) {
         std::this_thread::sleep_for(std::chrono::microseconds(50));
     }
@@ -355,7 +375,7 @@ void Context::drain_inference_queue(std::shared_ptr<SessionElement> session) {
 
     for (auto& inference_data : inference_stack) {
         if (!m_next_inference.try_enqueue(inference_data)) {
-            LOG_ERROR << "[ERROR] Could not requeue inference data!" << std::endl;
+            LOG_ERROR << "[ERROR] Could not requeue inference data!" << '\n';
         }
     }
 }
@@ -365,11 +385,11 @@ int Context::get_num_sessions() {
 }
 
 template <typename T>
-void Context::set_processor(std::shared_ptr<SessionElement> session,
+void Context::set_processor(const std::shared_ptr<SessionElement>& session,
                             InferenceConfig& inference_config,
                             std::vector<std::shared_ptr<T>>& processors,
                             anira::InferenceBackend backend) {
-    for (auto model_data : inference_config.m_model_data) {
+    for (const auto& model_data : inference_config.m_model_data) {
         if (model_data.m_backend == backend) {
             if (!inference_config.m_session_exclusive_processor) {
                 for (auto processor : processors) {
@@ -392,7 +412,7 @@ void Context::release_processor(InferenceConfig& inference_config,
                                 std::shared_ptr<T>& processor) {
     if (processor == nullptr) { return; }
     if (!inference_config.m_session_exclusive_processor) {
-        for (auto session : m_sessions) {
+        for (const auto& session : m_sessions) {
             if (session->m_inference_config == inference_config) { return; }
         }
     }
@@ -404,7 +424,7 @@ void Context::release_processor(InferenceConfig& inference_config,
     }
 }
 
-void Context::reset_session(std::shared_ptr<SessionElement> session) {
+void Context::reset_session(const std::shared_ptr<SessionElement>& session) {
     session->m_initialized.store(false, std::memory_order::release);
 
     drain_inference_queue(session);
@@ -415,7 +435,7 @@ void Context::reset_session(std::shared_ptr<SessionElement> session) {
 }
 
 moodycamel::ProducerToken& Context::get_producer_token() {
-    size_t index = m_next_producer_index.fetch_add(1) % m_producer_tokens.size();
+    size_t const index = m_next_producer_index.fetch_add(1) % m_producer_tokens.size();
     return *m_producer_tokens[index];
 }
 
@@ -429,7 +449,7 @@ std::unique_ptr<InferenceThread> Context::make_inference_thread() {
 
 #ifdef USE_LIBTORCH
 template void Context::set_processor<LibtorchProcessor>(
-    std::shared_ptr<SessionElement> session,
+    const std::shared_ptr<SessionElement>& session,
     InferenceConfig& inference_config,
     std::vector<std::shared_ptr<LibtorchProcessor>>& processors,
     InferenceBackend backend);
@@ -440,7 +460,7 @@ template void Context::release_processor<LibtorchProcessor>(
 #endif
 #ifdef USE_ONNXRUNTIME
 template void Context::set_processor<OnnxRuntimeProcessor>(
-    std::shared_ptr<SessionElement> session,
+    const std::shared_ptr<SessionElement>& session,
     InferenceConfig& inference_config,
     std::vector<std::shared_ptr<OnnxRuntimeProcessor>>& processors,
     InferenceBackend backend);
@@ -451,7 +471,7 @@ template void Context::release_processor<OnnxRuntimeProcessor>(
 #endif
 #ifdef USE_TFLITE
 template void Context::set_processor<TFLiteProcessor>(
-    std::shared_ptr<SessionElement> session,
+    const std::shared_ptr<SessionElement>& session,
     InferenceConfig& inference_config,
     std::vector<std::shared_ptr<TFLiteProcessor>>& processors,
     InferenceBackend backend);

--- a/src/scheduler/InferenceManager.cpp
+++ b/src/scheduler/InferenceManager.cpp
@@ -1,5 +1,18 @@
+#include <anira/ContextConfig.h>
+#include <anira/InferenceConfig.h>
+#include <anira/PrePostProcessor.h>
+#include <anira/backends/BackendBase.h>
+#include <anira/scheduler/Context.h>
 #include <anira/scheduler/InferenceManager.h>
+#include <anira/utils/HostConfig.h>
+#include <anira/utils/InferenceBackend.h>
 #include <anira/utils/Logger.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <utility>
+#include <vector>
 
 namespace anira {
 
@@ -27,7 +40,7 @@ InferenceBackend InferenceManager::get_backend() const {
 void InferenceManager::prepare(HostConfig new_config, std::vector<long> custom_latency) {
     m_host_config = new_config;
 
-    m_context->prepare_session(m_session, m_host_config, custom_latency);
+    m_context->prepare_session(m_session, m_host_config, std::move(custom_latency));
 
     m_missing_samples.clear();
     m_missing_samples.resize(m_inference_config.get_tensor_output_shape().size(), 0);
@@ -45,9 +58,9 @@ size_t* InferenceManager::process(const float* const* const* input_data,
         auto buffer_size_in_sec =
             static_cast<float>(num_input_samples[m_host_config.m_tensor_index]) /
             m_host_config.m_sample_rate;
-        auto timeToProcess = std::chrono::microseconds(
+        auto time_to_process = std::chrono::microseconds(
             static_cast<long>(buffer_size_in_sec * 1e6 * m_inference_config.m_blocking_ratio));
-        wait_until += timeToProcess;
+        wait_until += time_to_process;
         m_context->new_data_request(m_session, wait_until);
     } else {
         m_context->new_data_request(m_session);
@@ -63,7 +76,7 @@ void InferenceManager::push_data(const float* const* const* input_data, size_t* 
 
 size_t* InferenceManager::pop_data(float* const* const* output_data, size_t* num_output_samples) {
     if (m_inference_config.m_blocking_ratio > 0.f) {
-        std::chrono::steady_clock::time_point wait_until;
+        std::chrono::steady_clock::time_point const wait_until;
         m_context->new_data_request(m_session, wait_until);
     } else {
         m_context->new_data_request(m_session);
@@ -80,7 +93,7 @@ size_t* InferenceManager::pop_data(float* const* const* output_data,
     } else {
         LOG_ERROR << "[ERROR] InferenceConfig does not use blocking_ratio and does not use "
                      "semaphores for data acquisition, cannot wait for data!"
-                  << std::endl;
+                  << '\n';
     }
 
     return process_output(output_data, num_output_samples);
@@ -113,7 +126,7 @@ void InferenceManager::process_input(const float* const* const* input_data, size
 size_t* InferenceManager::process_output(float* const* const* output_data, size_t* num_samples) {
     for (size_t i = 0; i < m_inference_config.get_tensor_output_shape().size(); ++i) {
         if (m_inference_config.get_postprocess_output_size()[i] > 0) {
-            int missing_samples_before = m_missing_samples[i];
+            int const missing_samples_before = static_cast<int>(m_missing_samples[i]);
             while (m_missing_samples[i]) {
                 if (m_session->m_receive_buffer[i].get_available_samples(0) > num_samples[i]) {
                     for (size_t channel = 0;
@@ -130,7 +143,7 @@ size_t* InferenceManager::process_output(float* const* const* output_data, size_
                 LOG_INFO << "[WARNING] Catch up missing samples: "
                          << missing_samples_before - m_missing_samples[i]
                          << " in session: " << m_session->m_session_id << " for tensor index: " << i
-                         << "!" << std::endl;
+                         << "!" << '\n';
             }
         }
     }
@@ -173,7 +186,7 @@ size_t* InferenceManager::process_output(float* const* const* output_data, size_
                 m_missing_samples[i] += num_samples[i];
                 LOG_INFO << "[WARNING] Missing samples: " << m_missing_samples[i]
                          << " in session: " << m_session->m_session_id << " for tensor index: " << i
-                         << "!" << std::endl;
+                         << "!" << '\n';
             }
             num_samples[i] = 0;  // Set num_samples to 0 if not enough samples are available
         }

--- a/src/scheduler/InferenceThread.cpp
+++ b/src/scheduler/InferenceThread.cpp
@@ -1,5 +1,27 @@
 #include <anira/scheduler/InferenceThread.h>
+#include <anira/scheduler/SessionElement.h>
+#include <anira/utils/Buffer.h>
+#include <anira/utils/InferenceBackend.h>
 #include <anira/utils/Logger.h>
+#include <concurrentqueue.h>
+
+// IWYU pragma: keep - processor methods are called through SessionElement's shared_ptr members
+#ifdef USE_LIBTORCH
+#include <anira/backends/LibTorchProcessor.h>  // IWYU pragma: keep
+#endif
+#ifdef USE_ONNXRUNTIME
+#include <anira/backends/OnnxRuntimeProcessor.h>  // IWYU pragma: keep
+#endif
+#ifdef USE_TFLITE
+#include <anira/backends/TFLiteProcessor.h>  // IWYU pragma: keep
+#endif
+
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <thread>
+#include <vector>
 
 namespace anira {
 
@@ -36,11 +58,11 @@ bool InferenceThread::is_running() const {
 
 void InferenceThread::run_loop() {
     while (!should_exit()) {
-        constexpr std::array<int, 2> iterations = {4, 32};
+        constexpr std::array<int, 2> k_iterations = {4, 32};
         // The times for the exponential backoff. The first loop is insteadly trying to acquire the
         // atomic counter. The second loop is waiting for approximately 100ns. Beyond that, the
         // thread will yield and sleep for 100us.
-        exponential_backoff(iterations);
+        exponential_backoff(k_iterations);
     }
 }
 
@@ -97,8 +119,8 @@ bool InferenceThread::execute() {
 }
 
 void InferenceThread::do_inference(
-    std::shared_ptr<SessionElement> session,
-    std::shared_ptr<SessionElement::ThreadSafeStruct> thread_safe_struct) {
+    const std::shared_ptr<SessionElement>& session,
+    const std::shared_ptr<SessionElement::ThreadSafeStruct>& thread_safe_struct) {
     session->m_active_inferences.fetch_add(1, std::memory_order::release);
     inference(session,
               thread_safe_struct->m_tensor_input_data,
@@ -117,15 +139,16 @@ void InferenceThread::do_inference(
     if (session->m_inference_config.m_session_exclusive_processor) {
         session->release_dispatch();
         if (auto next = session->try_acquire_next_dispatch()) {
-            if (!m_next_inference.try_enqueue(InferenceData{session, next})) {
-                LOG_ERROR << "[ERROR] Could not enqueue next inference!" << std::endl;
+            if (!m_next_inference.try_enqueue(
+                    InferenceData{.m_session = session, .m_thread_safe_struct = next})) {
+                LOG_ERROR << "[ERROR] Could not enqueue next inference!" << '\n';
                 session->release_dispatch();
             }
         }
     }
 }
 
-void InferenceThread::inference(std::shared_ptr<SessionElement> session,
+void InferenceThread::inference(const std::shared_ptr<SessionElement>& session,
                                 std::vector<BufferF>& input,
                                 std::vector<BufferF>& output) {
 #ifdef USE_LIBTORCH
@@ -135,7 +158,7 @@ void InferenceThread::inference(std::shared_ptr<SessionElement> session,
         } else {
             session->m_default_processor.process(input, output, session);
             LOG_ERROR << "[ERROR] LibTorch model has not been provided. Using default processor."
-                      << std::endl;
+                      << '\n';
         }
     }
 #endif
@@ -146,7 +169,7 @@ void InferenceThread::inference(std::shared_ptr<SessionElement> session,
         } else {
             session->m_default_processor.process(input, output, session);
             LOG_ERROR << "[ERROR] OnnxRuntime model has not been provided. Using default processor."
-                      << std::endl;
+                      << '\n';
         }
     }
 #endif
@@ -157,7 +180,7 @@ void InferenceThread::inference(std::shared_ptr<SessionElement> session,
         } else {
             session->m_default_processor.process(input, output, session);
             LOG_ERROR << "[ERROR] TFLite model has not been provided. Using default processor."
-                      << std::endl;
+                      << '\n';
         }
     }
 #endif

--- a/src/scheduler/SessionElement.cpp
+++ b/src/scheduler/SessionElement.cpp
@@ -1,26 +1,43 @@
+#include <anira/InferenceConfig.h>
+#include <anira/PrePostProcessor.h>
 #include <anira/scheduler/SessionElement.h>
+#include <anira/utils/HostConfig.h>
+
+#ifdef USE_LIBTORCH
+#include <anira/backends/LibTorchProcessor.h>
+#endif
+#ifdef USE_ONNXRUNTIME
+#include <anira/backends/OnnxRuntimeProcessor.h>
+#endif
+#ifdef USE_TFLITE
+#include <anira/backends/TFLiteProcessor.h>
+#endif
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <cstddef>
+#include <memory>
+#include <utility>
+#include <vector>
 
 namespace anira {
 
-SessionElement::SessionElement(int newSessionID,
+SessionElement::SessionElement(int new_session_id,
                                PrePostProcessor& pp_processor,
                                InferenceConfig& inference_config)
-    : m_session_id(newSessionID)
+    : m_session_id(new_session_id)
     , m_pp_processor(pp_processor)
     , m_inference_config(inference_config)
     , m_default_processor(m_inference_config)
     , m_custom_processor(&m_default_processor) {}
 
-SessionElement::ThreadSafeStruct::ThreadSafeStruct(std::vector<size_t> tensor_input_size,
-                                                   std::vector<size_t> tensor_output_size) {
+SessionElement::ThreadSafeStruct::ThreadSafeStruct(const std::vector<size_t>& tensor_input_size,
+                                                   const std::vector<size_t>& tensor_output_size) {
     m_tensor_input_data.clear();
     m_tensor_output_data.clear();
-    for (size_t i = 0; i < tensor_input_size.size(); ++i) {
-        m_tensor_input_data.emplace_back(1, tensor_input_size[i]);
-    }
-    for (size_t i = 0; i < tensor_output_size.size(); ++i) {
-        m_tensor_output_data.emplace_back(1, tensor_output_size[i]);
-    }
+    for (unsigned long const& i : tensor_input_size) { m_tensor_input_data.emplace_back(1, i); }
+    for (unsigned long const& i : tensor_output_size) { m_tensor_output_data.emplace_back(1, i); }
 }
 
 void SessionElement::clear() {
@@ -95,7 +112,7 @@ void SessionElement::prepare(const HostConfig& host_config, std::vector<long> cu
 
     // Calculate the latency, number of structs needed
     m_latency.clear();
-    std::vector<float> latency = calculate_latency(host_config);
+    std::vector<float> const latency = calculate_latency(host_config);
     m_latency = sync_latencies(latency);
     m_num_structs = calculate_num_structs(host_config);
 
@@ -172,43 +189,46 @@ void SessionElement::prepare(const HostConfig& host_config, std::vector<long> cu
             std::vector<float> adjusted_latency;
             for (size_t i = 0; i < m_inference_config.get_tensor_output_shape().size(); ++i) {
                 if (m_inference_config.get_postprocess_output_size()[i] > 0) {
-                    float max_buffer_size =
+                    float const max_buffer_size =
                         host_config.get_relative_buffer_size(m_inference_config, i, false);
-                    float adjusted_buffer_size =
+                    float const adjusted_buffer_size =
                         adjusted_config.get_relative_buffer_size(m_inference_config, i, false);
-                    float min_buffer_size =
+                    float const min_buffer_size =
                         min_config.get_relative_buffer_size(m_inference_config, i, false);
-                    float sample_rate =
+                    float const sample_rate =
                         adjusted_config.get_relative_sample_rate(m_inference_config, i, false);
 
                     // When allowing smaller buffer sizes, the buffer adaptation is always the
                     // post-process output size minus one Because we could have buffers of size one
                     // only and this is the maximum adaptation possible
-                    int buffer_adaptation = std::max(
+                    int const buffer_adaptation = std::max(
                         static_cast<int>(m_inference_config.get_postprocess_output_size()[i]) - 1,
                         0);
 
-                    float max_wait_time = calculate_wait_time(max_buffer_size, sample_rate);
-                    float adjusted_wait_time =
+                    float const max_wait_time = calculate_wait_time(max_buffer_size, sample_rate);
+                    float const adjusted_wait_time =
                         calculate_wait_time(adjusted_buffer_size, sample_rate);
-                    float min_wait_time = calculate_wait_time(min_buffer_size, sample_rate);
+                    float const min_wait_time = calculate_wait_time(min_buffer_size, sample_rate);
 
-                    float max_possible_inferences = std::max(max_num_inferences(adjusted_config),
-                                                             max_num_inferences(host_config));
+                    float const max_possible_inferences =
+                        std::max(max_num_inferences(adjusted_config),
+                                 max_num_inferences(host_config));
 
-                    int inference_caused_latency_max_buffer = calculate_inference_caused_latency(
-                        max_possible_inferences,
-                        max_buffer_size,
-                        sample_rate,
-                        max_wait_time,
-                        m_inference_config.get_postprocess_output_size()[i]);
-                    int inference_caused_latency_min_buffer = calculate_inference_caused_latency(
-                        1,
-                        min_buffer_size,
-                        sample_rate,
-                        min_wait_time,
-                        m_inference_config.get_postprocess_output_size()[i]);
-                    int inference_caused_latency_adjusted_buffer =
+                    int const inference_caused_latency_max_buffer =
+                        calculate_inference_caused_latency(
+                            max_possible_inferences,
+                            max_buffer_size,
+                            sample_rate,
+                            max_wait_time,
+                            m_inference_config.get_postprocess_output_size()[i]);
+                    int const inference_caused_latency_min_buffer =
+                        calculate_inference_caused_latency(
+                            1,
+                            min_buffer_size,
+                            sample_rate,
+                            min_wait_time,
+                            m_inference_config.get_postprocess_output_size()[i]);
+                    int const inference_caused_latency_adjusted_buffer =
                         calculate_inference_caused_latency(
                             max_num_inferences(adjusted_config),
                             adjusted_buffer_size,
@@ -222,7 +242,8 @@ void SessionElement::prepare(const HostConfig& host_config, std::vector<long> cu
                     inference_caused_latency =
                         std::max(inference_caused_latency, inference_caused_latency_min_buffer);
 
-                    adjusted_latency.push_back(inference_caused_latency + buffer_adaptation);
+                    adjusted_latency.push_back(
+                        static_cast<float>(inference_caused_latency + buffer_adaptation));
                 }
             }
 
@@ -235,7 +256,7 @@ void SessionElement::prepare(const HostConfig& host_config, std::vector<long> cu
                 }
             }
 
-            size_t adjusted_num_structs = calculate_num_structs(adjusted_config);
+            size_t const adjusted_num_structs = calculate_num_structs(adjusted_config);
 
             if (adjusted_num_structs > m_num_structs) { m_num_structs = adjusted_num_structs; }
         }
@@ -302,10 +323,10 @@ void SessionElement::prepare(const HostConfig& host_config, std::vector<long> cu
     // Create the thread-safe structs for the inference queue
     m_inference_queue.clear();
 
-    std::vector<size_t> tensor_input_size = m_inference_config.get_tensor_input_size();
-    std::vector<size_t> tensor_output_size = m_inference_config.get_tensor_output_size();
+    std::vector<size_t> const tensor_input_size = m_inference_config.get_tensor_input_size();
+    std::vector<size_t> const tensor_output_size = m_inference_config.get_tensor_output_size();
 
-    for (int i = 0; i < m_num_structs; ++i) {
+    for (size_t i = 0; i < m_num_structs; ++i) {
         m_inference_queue.emplace_back(
             std::make_unique<ThreadSafeStruct>(tensor_input_size, tensor_output_size));
     }
@@ -317,17 +338,17 @@ void SessionElement::prepare(const HostConfig& host_config, std::vector<long> cu
 template <typename T>
 void SessionElement::set_processor(std::shared_ptr<T>& processor) {
 #ifdef USE_LIBTORCH
-    if (std::is_same<T, LibtorchProcessor>::value) {
+    if (std::is_same_v<T, LibtorchProcessor>) {
         m_libtorch_processor = std::dynamic_pointer_cast<LibtorchProcessor>(processor);
     }
 #endif
 #ifdef USE_ONNXRUNTIME
-    if (std::is_same<T, OnnxRuntimeProcessor>::value) {
+    if (std::is_same_v<T, OnnxRuntimeProcessor>) {
         m_onnx_processor = std::dynamic_pointer_cast<OnnxRuntimeProcessor>(processor);
     }
 #endif
 #ifdef USE_TFLITE
-    if (std::is_same<T, TFLiteProcessor>::value) {
+    if (std::is_same_v<T, TFLiteProcessor>) {
         m_tflite_processor = std::dynamic_pointer_cast<TFLiteProcessor>(processor);
     }
 #endif
@@ -335,43 +356,45 @@ void SessionElement::set_processor(std::shared_ptr<T>& processor) {
 
 size_t SessionElement::calculate_num_structs(const HostConfig& host_config) const {
     // Now calculate the number of structs necessary to keep the inference queues filled
-    float max_inference_time_in_samples =
+    float const max_inference_time_in_samples =
         m_inference_config.m_max_inference_time * host_config.m_sample_rate / 1000;
-    int new_samples_needed_for_inference =
-        m_inference_config.get_preprocess_input_size()[host_config.m_tensor_index];
-    int max_possible_inferences = (int)max_num_inferences(host_config);
-    int structs_per_max_inference_time =
+    int const new_samples_needed_for_inference = static_cast<int>(
+        m_inference_config.get_preprocess_input_size()[host_config.m_tensor_index]);
+    int const max_possible_inferences = (int)max_num_inferences(host_config);
+    int const structs_per_max_inference_time =
         std::ceil((float)max_inference_time_in_samples / (float)new_samples_needed_for_inference);
     // We need to multiply the number of structs per max inference time with the maximum possible
     // inferences, because all can run in parallel
-    int n_structs =
+    int const n_structs =
         (int)(max_possible_inferences + structs_per_max_inference_time * max_possible_inferences);
     return n_structs;
 }
 
 std::vector<float> SessionElement::calculate_latency(const HostConfig& host_config) {
     std::vector<float> result_float;
-    float max_possible_inferences = max_num_inferences(host_config);
+    float const max_possible_inferences = max_num_inferences(host_config);
     for (size_t i = 0; i < m_inference_config.get_postprocess_output_size().size(); ++i) {
         if (m_inference_config.get_postprocess_output_size()[i] <= 0) {
             result_float.push_back(0);
         } else {
-            float host_output_size =
+            float const host_output_size =
                 host_config.get_relative_buffer_size(m_inference_config, i, false);
-            float sample_rate = host_config.get_relative_sample_rate(m_inference_config, i, false);
+            float const sample_rate =
+                host_config.get_relative_sample_rate(m_inference_config, i, false);
             // Calculate the different parts of the latency
-            int buffer_adaptation =
-                calculate_buffer_adaptation(host_output_size,
-                                            m_inference_config.get_postprocess_output_size()[i]);
-            float wait_time = calculate_wait_time(host_output_size, sample_rate);
-            int inference_caused_latency = calculate_inference_caused_latency(
+            int const buffer_adaptation = calculate_buffer_adaptation(
+                host_output_size,
+                static_cast<int>(m_inference_config.get_postprocess_output_size()[i]));
+            float const wait_time = calculate_wait_time(host_output_size, sample_rate);
+            int const inference_caused_latency = calculate_inference_caused_latency(
                 max_possible_inferences,
                 host_output_size,
                 sample_rate,
                 wait_time,
                 m_inference_config.get_postprocess_output_size()[i]);
             // Add it all together
-            result_float.push_back(buffer_adaptation + inference_caused_latency);
+            result_float.push_back(
+                static_cast<float>(buffer_adaptation + inference_caused_latency));
         }
     }
 
@@ -388,13 +411,15 @@ std::vector<unsigned int> SessionElement::sync_latencies(
             if (m_inference_config.get_postprocess_output_size()[i] > 0) {
                 latency_ratio = std::max<float>(
                     latency_ratio,
-                    latencies[i] / m_inference_config.get_postprocess_output_size()[i]);
+                    latencies[i] /
+                        static_cast<float>(m_inference_config.get_postprocess_output_size()[i]));
             }
         }
         for (size_t i = 0; i < latencies.size(); ++i) {
             if (m_inference_config.get_postprocess_output_size()[i] > 0) {
-                result.push_back(std::ceil(latency_ratio) *
-                                 m_inference_config.get_postprocess_output_size()[i]);
+                result.push_back(static_cast<unsigned int>(
+                    std::ceil(latency_ratio) *
+                    static_cast<float>(m_inference_config.get_postprocess_output_size()[i])));
             } else {
                 result.push_back(0);  // If no output size, just return 0
             }
@@ -409,10 +434,12 @@ std::vector<unsigned int> SessionElement::sync_latencies(
 int SessionElement::calculate_buffer_adaptation(float host_buffer_size,
                                                 int postprocess_output_size) const {
     int res = 0;
+    // NOLINTNEXTLINE(clang-analyzer-security.FloatLoopCounter) intentional fractional buffer step
     for (float i = host_buffer_size;
-         i < least_common_multiple(std::floor(host_buffer_size), postprocess_output_size);
+         i < static_cast<float>(
+                 least_common_multiple(std::floor(host_buffer_size), postprocess_output_size));
          i += host_buffer_size) {
-        float remainder = std::fmod(i, (float)postprocess_output_size);
+        float const remainder = std::fmod(i, (float)postprocess_output_size);
         res = std::max<int>(res, std::ceil(remainder));
     }
     // We do not want special handling of float buffer sizes as the user must then only pop data if
@@ -425,14 +452,12 @@ int SessionElement::calculate_inference_caused_latency(float max_possible_infere
                                                        float host_sample_rate,
                                                        float wait_time,
                                                        size_t postprocess_output_size) const {
-    // Calculate the host buffer time in ms
-    float host_buffer_time = host_buffer_size * 1000.f / host_sample_rate;
     float inference_time_left = 0.f;
-    float host_buffer_size_int = std::floor(host_buffer_size);
-    float host_buffer_time_int = host_buffer_size_int * 1000.f / host_sample_rate;
+    float const host_buffer_size_int = std::floor(host_buffer_size);
+    float const host_buffer_time_int = host_buffer_size_int * 1000.f / host_sample_rate;
     float inference_caused_latency = 0;
 
-    unsigned int max_inference_batches = static_cast<unsigned int>(
+    auto const max_inference_batches = static_cast<unsigned int>(
         std::ceil((max_possible_inferences) /
                   static_cast<float>(m_inference_config.m_num_parallel_processors)));
     float already_inferred = 0;
@@ -442,37 +467,36 @@ int SessionElement::calculate_inference_caused_latency(float max_possible_infere
         inference_time_left += m_inference_config.m_max_inference_time;
 
         if (wait_time_left >= m_inference_config.m_max_inference_time) {
-            already_inferred += m_inference_config.m_num_parallel_processors;
+            already_inferred += static_cast<float>(m_inference_config.m_num_parallel_processors);
             wait_time_left -= m_inference_config.m_max_inference_time;
         }
 
         if (host_buffer_time_int > 0) {
-            int iterations = inference_time_left / host_buffer_time_int;
-            inference_caused_latency += iterations * host_buffer_size_int;
-            inference_time_left -= iterations * host_buffer_time_int;
+            int const iterations = static_cast<int>(inference_time_left / host_buffer_time_int);
+            inference_caused_latency += static_cast<float>(iterations) * host_buffer_size_int;
+            inference_time_left -= static_cast<float>(iterations) * host_buffer_time_int;
         }
     }
 
     if (inference_time_left > wait_time) {
         if (host_buffer_time_int > 0) {
-            inference_time_left -= host_buffer_time_int;
             inference_caused_latency += host_buffer_size_int;
         } else {
             inference_caused_latency += 1;
         }
     }
 
-    inference_caused_latency -= already_inferred * postprocess_output_size;
+    inference_caused_latency -= already_inferred * static_cast<float>(postprocess_output_size);
 
     return std::max(static_cast<int>(std::ceil(inference_caused_latency)), 0);
 }
 
 float SessionElement::calculate_wait_time(float host_buffer_size, float host_sample_rate) const {
     // Calculate the host buffer time in ms
-    float host_buffer_time = host_buffer_size * 1000.f / host_sample_rate;
+    float const host_buffer_time = host_buffer_size * 1000.f / host_sample_rate;
     // If we use controlled blocking, we need to wait for the process to finish before we can
     // continue
-    float wait_time = m_inference_config.m_blocking_ratio * host_buffer_time;
+    float const wait_time = m_inference_config.m_blocking_ratio * host_buffer_time;
     return wait_time;
 }
 
@@ -480,19 +504,23 @@ float SessionElement::max_num_inferences(const HostConfig& host_config) const {
     float max_possible_inferences = 0.f;
     for (size_t i = 0; i < m_inference_config.get_tensor_input_shape().size(); ++i) {
         if (m_inference_config.get_preprocess_input_size()[i] > 0) {
-            float host_buffer_size =
+            float const host_buffer_size =
                 host_config.get_relative_buffer_size(m_inference_config, i, true);
-            int postprocess_input_size = m_inference_config.get_preprocess_input_size()[i];
+            int const postprocess_input_size =
+                static_cast<int>(m_inference_config.get_preprocess_input_size()[i]);
             float samples_in_buffer = host_buffer_size;
             int res = (int)(samples_in_buffer / (float)postprocess_input_size);
             res = std::max<int>(res, 1);
             int num_inferences = 0;
+            // NOLINTNEXTLINE(clang-analyzer-security.FloatLoopCounter): fractional buffer step
             for (float i = samples_in_buffer;
-                 i < least_common_multiple(std::floor(host_buffer_size), postprocess_input_size);
+                 i < static_cast<float>(least_common_multiple(std::floor(host_buffer_size),
+                                                              postprocess_input_size));
                  i += host_buffer_size) {
                 num_inferences = (int)(samples_in_buffer / (float)postprocess_input_size);
                 res = std::max<int>(res, num_inferences);
-                samples_in_buffer += host_buffer_size - num_inferences * postprocess_input_size;
+                samples_in_buffer +=
+                    host_buffer_size - static_cast<float>(num_inferences * postprocess_input_size);
             }
             // Here we handle the maximum number of inferences that can be done with a float buffer
             // size
@@ -503,7 +531,9 @@ float SessionElement::max_num_inferences(const HostConfig& host_config) const {
                     num_inferences = (int)(samples_in_buffer / (float)postprocess_input_size);
                     res = std::max<int>(res, num_inferences);
                     remainder = std::fmod(samples_in_buffer, 1.f);
-                    samples_in_buffer += host_buffer_size - num_inferences * postprocess_input_size;
+                    samples_in_buffer +=
+                        host_buffer_size -
+                        static_cast<float>(num_inferences * postprocess_input_size);
                 } while (remainder > std::fmod(samples_in_buffer, 1.f));
             }
             max_possible_inferences = std::max(max_possible_inferences, (float)res);
@@ -513,11 +543,12 @@ float SessionElement::max_num_inferences(const HostConfig& host_config) const {
 }
 
 int SessionElement::greatest_common_divisor(int a, int b) const {
-    if (b == 0) {
-        return a;
-    } else {
-        return greatest_common_divisor(b, a % b);
+    while (b != 0) {
+        int const t = b;
+        b = a % b;
+        a = t;
     }
+    return a;
 }
 
 int SessionElement::least_common_multiple(int a, int b) const {
@@ -530,12 +561,14 @@ std::vector<size_t> SessionElement::calculate_send_buffer_sizes(
 
     for (size_t i = 0; i < m_inference_config.get_tensor_input_shape().size(); ++i) {
         if (m_inference_config.get_preprocess_input_size()[i] > 0) {
-            int host_input_size =
+            int const host_input_size =
                 std::ceil(host_config.get_relative_buffer_size(m_inference_config, i, true));
-            int preprocess_input_size = m_inference_config.get_preprocess_input_size()[i];
-            int buffer_adaptation =
-                calculate_buffer_adaptation(host_input_size, preprocess_input_size);
-            int past_samples_needed = std::max(
+            int const preprocess_input_size =
+                static_cast<int>(m_inference_config.get_preprocess_input_size()[i]);
+            int const buffer_adaptation =
+                calculate_buffer_adaptation(static_cast<float>(host_input_size),
+                                            preprocess_input_size);
+            int const past_samples_needed = std::max(
                 static_cast<int>(
                     static_cast<float>(m_inference_config.get_tensor_input_size()[i]) /
                     static_cast<float>(m_inference_config.get_preprocess_input_channels()[i])) -
@@ -552,12 +585,13 @@ std::vector<size_t> SessionElement::calculate_send_buffer_sizes(
 }
 
 std::vector<size_t> SessionElement::calculate_receive_buffer_sizes(
-    const HostConfig& host_config) const {
+    const HostConfig& /*host_config*/) const {
     std::vector<size_t> receive_buffer_sizes;
     for (size_t i = 0; i < m_inference_config.get_tensor_output_shape().size(); ++i) {
         if (m_inference_config.get_postprocess_output_size()[i] > 0) {
-            int postprocess_output_size = m_inference_config.get_postprocess_output_size()[i];
-            int new_samples = std::ceil(m_num_structs * postprocess_output_size);
+            int const postprocess_output_size =
+                static_cast<int>(m_inference_config.get_postprocess_output_size()[i]);
+            int const new_samples = std::ceil(m_num_structs * postprocess_output_size);
             receive_buffer_sizes.push_back(new_samples + m_latency[i]);
         } else {
             receive_buffer_sizes.push_back(0);

--- a/src/system/HighPriorityThread.cpp
+++ b/src/system/HighPriorityThread.cpp
@@ -1,6 +1,18 @@
 #include <anira/system/HighPriorityThread.h>
 #include <anira/utils/Logger.h>
 
+#include <cerrno>
+
+// POSIX threading/scheduling headers are only available (and only used) on the
+// non-Windows code paths below.
+#if defined(__linux__) || defined(__APPLE__)
+#include <pthread.h>
+#endif
+#if defined(__linux__)
+#include <sched.h>
+#include <sys/resource.h>
+#endif
+
 namespace anira {
 
 HighPriorityThread::HighPriorityThread() : m_should_exit(false) {}
@@ -13,6 +25,8 @@ void HighPriorityThread::start() {
     if (!m_thread.joinable()) {
         m_should_exit = false;
 #if __linux__
+        // pthread_attr_t comes portably from <pthread.h>, not the glibc-internal <bits/...>
+        // NOLINTNEXTLINE(misc-include-cleaner)
         pthread_attr_t thread_attr;
         pthread_attr_init(&thread_attr);
         pthread_attr_setinheritsched(&thread_attr, PTHREAD_EXPLICIT_SCHED);
@@ -64,28 +78,32 @@ void HighPriorityThread::elevate_priority(std::thread::native_handle_type thread
 
     if (!is_main_process) {
         int attr_inheritsched;
+        // pthread_attr_t comes portably from <pthread.h>, not the glibc-internal <bits/...>
+        // NOLINTNEXTLINE(misc-include-cleaner)
         pthread_attr_t thread_attr;
-        ret = pthread_getattr_np(thread_native_handle, &thread_attr);
+        pthread_getattr_np(thread_native_handle, &thread_attr);
         ret = pthread_attr_getinheritsched(&thread_attr, &attr_inheritsched);
         if (ret != 0) {
             LOG_ERROR << "[ERROR] Failed to get Thread scheduling policy and params : " << errno
-                      << std::endl;
+                      << '\n';
         }
         if (attr_inheritsched != PTHREAD_EXPLICIT_SCHED) {
             LOG_ERROR << "[ERROR] Thread scheduling policy is not PTHREAD_EXPLICIT_SCHED. Possibly "
                          "thread attributes get inherited from the main process."
-                      << std::endl;
+                      << '\n';
         }
         pthread_attr_destroy(&thread_attr);
     }
 
     int sch_policy;
+    // sched_param comes portably from <sched.h>, not the glibc-internal <bits/...>
+    // NOLINTNEXTLINE(misc-include-cleaner)
     struct sched_param sch_params;
 
     ret = pthread_getschedparam(thread_native_handle, &sch_policy, &sch_params);
     if (ret != 0) {
         LOG_ERROR << "[ERROR] Failed to get Thread scheduling policy and params : " << errno
-                  << std::endl;
+                  << '\n';
     }
 
     // Pipewire uses SCHED_FIFO 60 and juce plugin host uses SCHED_FIFO 55 better stay below
@@ -95,19 +113,18 @@ void HighPriorityThread::elevate_priority(std::thread::native_handle_type thread
     if (ret != 0) {
         LOG_ERROR << "[ERROR] Failed to set Thread scheduling policy to SCHED_FIFO and increase "
                      "the sched_priority to "
-                  << sch_params.sched_priority << ". Error : " << errno << std::endl;
+                  << sch_params.sched_priority << ". Error : " << errno << '\n';
         LOG_INFO << "[WARNING] Give rtprio privileges to the user by adding the user to the "
                     "realtime/audio group. Or run the application as root."
-                 << std::endl;
+                 << '\n';
         LOG_INFO << "[WARNING] Instead, trying to set increased nice value for SCHED_OTHER..."
-                 << std::endl;
+                 << '\n';
 
         ret = setpriority(PRIO_PROCESS, 0, -10);
         if (ret != 0) {
-            LOG_ERROR << "[ERROR] Failed to set increased nice value. Error : " << errno
-                      << std::endl;
+            LOG_ERROR << "[ERROR] Failed to set increased nice value. Error : " << errno << '\n';
             LOG_INFO << "[WARNING] Using default nice value: " << getpriority(PRIO_PROCESS, 0)
-                     << std::endl;
+                     << '\n';
         }
     }
 

--- a/src/utils/JsonConfigLoader.cpp
+++ b/src/utils/JsonConfigLoader.cpp
@@ -1,11 +1,23 @@
+#include <anira/ContextConfig.h>
+#include <anira/InferenceConfig.h>
+#include <anira/utils/InferenceBackend.h>
 #include <anira/utils/JsonConfigLoader.h>
 #include <anira/utils/Logger.h>
 
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
 #include <iostream>
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <nlohmann/json_fwd.hpp>  // IWYU pragma: keep - declares the nlohmann::json type name
+#include <string>
+#include <utility>
+#include <vector>
 
 anira::JsonConfigLoader::JsonConfigLoader(const std::string& file_path) {
     std::ifstream config_file(file_path);
-    if (!config_file.is_open()) { LOG_ERROR << "Could not open file at " + file_path << std::endl; }
+    if (!config_file.is_open()) { LOG_ERROR << "Could not open file at " + file_path << '\n'; }
     initialize_from_stream(config_file);
 }
 
@@ -27,7 +39,7 @@ void anira::JsonConfigLoader::initialize_from_stream(std::istream& stream) {
         stream >> json_config;
         parse(json_config);
     } catch (const nlohmann::json::parse_error& e) {
-        LOG_ERROR << "JSON parse error: " << e.what() << std::endl;
+        LOG_ERROR << "JSON parse error: " << e.what() << '\n';
     }
 }
 
@@ -46,11 +58,11 @@ void anira::JsonConfigLoader::parse_context_config(const nlohmann::json& config)
         }
 
         if (context_json.at("num_threads").is_number_unsigned()) {
-            unsigned int num_threads = context_json.at("num_threads").get<unsigned int>();
+            unsigned int const num_threads = context_json.at("num_threads").get<unsigned int>();
             m_context_config = std::make_unique<anira::ContextConfig>(num_threads);
             return;
         } else {
-            LOG_ERROR << "Invalid 'num_threads' value: expected an unsigned integer." << std::endl;
+            LOG_ERROR << "Invalid 'num_threads' value: expected an unsigned integer." << '\n';
         }
     }
 
@@ -59,7 +71,7 @@ void anira::JsonConfigLoader::parse_context_config(const nlohmann::json& config)
 
 void anira::JsonConfigLoader::parse_inference_config(const nlohmann::json& config) {
     if (!config.contains("inference_config")) {
-        LOG_ERROR << "Missing 'inference_config' key." << std::endl;
+        LOG_ERROR << "Missing 'inference_config' key." << '\n';
         return;
     }
 
@@ -121,12 +133,12 @@ std::vector<anira::ModelData> anira::JsonConfigLoader::create_model_data_from_co
     std::vector<anira::ModelData> model_data;
 
     if (!config.is_array()) {
-        LOG_ERROR << "Invalid 'model_data' value: expected an array." << std::endl;
+        LOG_ERROR << "Invalid 'model_data' value: expected an array." << '\n';
         return model_data;
     }
 
     if (config.empty()) {
-        LOG_ERROR << "Invalid 'model_data' array: empty array." << std::endl;
+        LOG_ERROR << "Invalid 'model_data' array: empty array." << '\n';
         return model_data;
     }
 
@@ -134,17 +146,17 @@ std::vector<anira::ModelData> anira::JsonConfigLoader::create_model_data_from_co
         if (!item.contains("model_path") || !item.contains("inference_backend")) {
             LOG_ERROR << "Missing key pair 'model_path' and 'inference_backend' in "
                          "'model_data' array entry."
-                      << std::endl;
+                      << '\n';
             continue;
         }
 
         if (!item.at("model_path").is_string()) {
-            LOG_ERROR << "Invalid 'model_path' value: expected a string." << std::endl;
+            LOG_ERROR << "Invalid 'model_path' value: expected a string." << '\n';
             continue;
         }
 
         if (!item.at("inference_backend").is_string()) {
-            LOG_ERROR << "Invalid 'inference_backend' value: expected a string." << std::endl;
+            LOG_ERROR << "Invalid 'inference_backend' value: expected a string." << '\n';
             continue;
         }
 
@@ -173,7 +185,7 @@ std::vector<anira::ModelData> anira::JsonConfigLoader::create_model_data_from_co
                 if (!item.at("model_function").is_string()) {
                     LOG_ERROR << "Invalid 'model_function' value in 'model_data' array "
                                  "entry: expected a string."
-                              << std::endl;
+                              << '\n';
                     continue;
                 }
                 const std::string model_function = item.at("model_function").get<std::string>();
@@ -194,7 +206,7 @@ std::vector<anira::ModelData> anira::JsonConfigLoader::create_model_data_from_co
             LOG_ERROR << "Invalid 'inference_backend' value in 'model_data' array "
                          "entry : expected a string of the following list ['ONNX', "
                          "'TFLITE', 'LIBTORCH', 'CUSTOM']."
-                      << std::endl;
+                      << '\n';
         }
     }
 
@@ -206,12 +218,12 @@ std::vector<anira::TensorShape> anira::JsonConfigLoader::create_tensor_shape_fro
     std::vector<anira::TensorShape> tensor_shape;
 
     if (!config.is_array()) {
-        LOG_ERROR << "Invalid 'tensor_shape' value: expected an array." << std::endl;
+        LOG_ERROR << "Invalid 'tensor_shape' value: expected an array." << '\n';
         return tensor_shape;
     }
 
     if (config.empty()) {
-        LOG_ERROR << "Invalid 'tensor_shape' array: empty array." << std::endl;
+        LOG_ERROR << "Invalid 'tensor_shape' array: empty array." << '\n';
         return tensor_shape;
     }
 
@@ -219,15 +231,15 @@ std::vector<anira::TensorShape> anira::JsonConfigLoader::create_tensor_shape_fro
         if (!item.contains("input_shape") || !item.contains("output_shape")) {
             LOG_ERROR << "Missing key pair 'input_shape' and 'output_shape' in "
                          "'tensor_shape' array entry."
-                      << std::endl;
+                      << '\n';
             continue;
         }
 
         const auto& input_shape = item.at("input_shape");
         const auto& output_shape = item.at("output_shape");
 
-        anira::TensorShapeList input_shape_list = parse_tensor_json_shape(input_shape);
-        anira::TensorShapeList output_shape_list = parse_tensor_json_shape(output_shape);
+        anira::TensorShapeList const input_shape_list = parse_tensor_json_shape(input_shape);
+        anira::TensorShapeList const output_shape_list = parse_tensor_json_shape(output_shape);
 
         std::string tensor_backend = "UNIVERSAL";
 
@@ -237,7 +249,7 @@ std::vector<anira::TensorShape> anira::JsonConfigLoader::create_tensor_shape_fro
             } else {
                 LOG_ERROR << "Invalid 'inference_backend' value in 'tensor_shape' "
                              "array entry: expected a string."
-                          << std::endl;
+                          << '\n';
             }
         }
 
@@ -281,7 +293,7 @@ std::vector<anira::TensorShape> anira::JsonConfigLoader::create_tensor_shape_fro
             LOG_ERROR << "Invalid 'inference_backend' value in 'tensor_shape' array "
                          "entry : expected a string of the following list ['ONNX', "
                          "'TFLITE', 'LIBTORCH']."
-                      << std::endl;
+                      << '\n';
         }
     }
 
@@ -293,25 +305,24 @@ anira::TensorShapeList anira::JsonConfigLoader::parse_tensor_json_shape(
     if (!shape_node.is_array()) {
         LOG_ERROR << "Invalid 'shape' value in 'tensor_shape' array entry: "
                      "expected an array."
-                  << std::endl;
+                  << '\n';
     }
 
     if (shape_node.empty()) {
-        LOG_ERROR << "Invalid 'shape' value in 'tensor_shape' array entry: empty array."
-                  << std::endl;
+        LOG_ERROR << "Invalid 'shape' value in 'tensor_shape' array entry: empty array." << '\n';
         return {};
     }
 
     if (shape_node.front().is_array()) { return shape_node.get<anira::TensorShapeList>(); }
 
     if (shape_node.front().is_number()) {
-        std::vector<int64_t> flat_shape = shape_node.get<std::vector<int64_t>>();
+        std::vector<int64_t> const flat_shape = shape_node.get<std::vector<int64_t>>();
         return {flat_shape};
     }
 
     LOG_ERROR << "Invalid 'shape' value inside 'tensor_shape' array entry: "
                  "expected an array."
-              << std::endl;
+              << '\n';
     return {};
 }
 
@@ -360,21 +371,21 @@ anira::ProcessingSpec anira::JsonConfigLoader::create_processing_spec_from_confi
 
 std::vector<size_t> anira::JsonConfigLoader::parse_size_t_json_shape(
     const nlohmann::json& shape_node,
-    std::string json_key_name) {
+    const std::string& json_key_name) {
     if (!shape_node.is_array()) {
-        LOG_ERROR << "Invalid '" << json_key_name << "' value: expected an array." << std::endl;
+        LOG_ERROR << "Invalid '" << json_key_name << "' value: expected an array." << '\n';
         return {};
     }
 
     if (shape_node.empty()) {
-        LOG_ERROR << "Invalid '" << json_key_name << "' array: empty array." << std::endl;
+        LOG_ERROR << "Invalid '" << json_key_name << "' array: empty array." << '\n';
         return {};
     }
 
     if (shape_node.front().is_number_unsigned()) { return shape_node.get<std::vector<size_t>>(); }
 
     LOG_ERROR << "Invalid '" << json_key_name << "' array: expected an unsigned integer array."
-              << std::endl;
+              << '\n';
     return {};
 }
 
@@ -391,10 +402,10 @@ anira::JsonConfigLoader::SingleParameterStruct
             single_parameters.m_max_inference_time = max_inference_time;
             necessary_parameter_set = true;
         } else {
-            LOG_ERROR << "Invalid 'max_inference_time' value: expected a float." << std::endl;
+            LOG_ERROR << "Invalid 'max_inference_time' value: expected a float." << '\n';
         }
     } else {
-        LOG_ERROR << "Missing 'max_inference_time' key." << std::endl;
+        LOG_ERROR << "Missing 'max_inference_time' key." << '\n';
     }
 
     if (config.contains("warm_up")) {
@@ -403,7 +414,7 @@ anira::JsonConfigLoader::SingleParameterStruct
             const unsigned int warm_up = warm_up_json.get<unsigned int>();
             single_parameters.m_warm_up = warm_up;
         } else {
-            LOG_ERROR << "Invalid 'warm_up' value: expected an unsigned integer." << std::endl;
+            LOG_ERROR << "Invalid 'warm_up' value: expected an unsigned integer." << '\n';
         }
     }
 
@@ -413,8 +424,7 @@ anira::JsonConfigLoader::SingleParameterStruct
             const bool session_exclusive_processor = session_exclusive_processor_json.get<bool>();
             single_parameters.m_session_exclusive_processor = session_exclusive_processor;
         } else {
-            LOG_ERROR << "Invalid 'session_exclusive_processor' value: expected a bool."
-                      << std::endl;
+            LOG_ERROR << "Invalid 'session_exclusive_processor' value: expected a bool." << '\n';
         }
     }
 
@@ -424,7 +434,7 @@ anira::JsonConfigLoader::SingleParameterStruct
             const float blocking_ratio = blocking_ratio_json.get<float>();
             single_parameters.m_blocking_ratio = blocking_ratio;
         } else {
-            LOG_ERROR << "Invalid 'blocking_ratio' value: expected a float." << std::endl;
+            LOG_ERROR << "Invalid 'blocking_ratio' value: expected a float." << '\n';
         }
     }
 
@@ -437,7 +447,7 @@ anira::JsonConfigLoader::SingleParameterStruct
         } else {
             LOG_ERROR << "Invalid 'num_parallel_processors' value: expected an "
                          "unsigned integer."
-                      << std::endl;
+                      << '\n';
         }
     }
 

--- a/src/utils/RingBuffer.cpp
+++ b/src/utils/RingBuffer.cpp
@@ -1,6 +1,8 @@
 #include <anira/utils/Logger.h>
 #include <anira/utils/RingBuffer.h>
 
+#include <cstddef>
+
 namespace anira {
 
 RingBuffer::RingBuffer() = default;
@@ -32,7 +34,7 @@ void RingBuffer::push_sample(size_t channel, float sample) {
     // Check if we're about to overwrite unread data (buffer overflow)
     if (m_is_full[channel]) {
         LOG_ERROR << "RingBuffer: Buffer overflow detected for channel " << channel
-                  << ". Overwriting oldest sample." << std::endl;
+                  << ". Overwriting oldest sample." << '\n';
         // Advance read position to make room (overwrite oldest sample)
         ++m_read_pos[channel];
         if (m_read_pos[channel] >= get_num_samples()) { m_read_pos[channel] = 0; }
@@ -53,7 +55,7 @@ float RingBuffer::pop_sample(size_t channel) {
     // Check if buffer is empty
     if (!m_is_full[channel] && m_read_pos[channel] == m_write_pos[channel]) {
         LOG_ERROR << "RingBuffer: Attempted to pop sample from empty buffer for channel " << channel
-                  << ". Returning silence (0.0f)." << std::endl;
+                  << ". Returning silence (0.0f)." << '\n';
         return 0.0f;
     }
 
@@ -72,12 +74,12 @@ float RingBuffer::get_future_sample(size_t channel, size_t offset) {
     if (offset >= get_available_samples(channel)) {
         LOG_ERROR << "RingBuffer: Attempted to get sample with offset " << offset << " for channel "
                   << channel << ", but only " << get_available_samples(channel)
-                  << " samples are available. Returning silence (0.0f)." << std::endl;
+                  << " samples are available. Returning silence (0.0f)." << '\n';
         return 0.0f;
     }
 
     // Calculate the actual position in the buffer
-    size_t sample_pos = (m_read_pos[channel] + offset) % get_num_samples();
+    size_t const sample_pos = (m_read_pos[channel] + offset) % get_num_samples();
     return get_sample(channel, sample_pos);
 }
 
@@ -87,7 +89,7 @@ float RingBuffer::get_past_sample(size_t channel, size_t offset) {
         LOG_ERROR << "RingBuffer: Attempted to get past sample with offset " << offset
                   << " for channel " << channel << ", but only "
                   << get_available_past_samples(channel)
-                  << " past samples are available. Returning silence (0.0f)." << std::endl;
+                  << " past samples are available. Returning silence (0.0f)." << '\n';
         return 0.0f;
     }
 

--- a/test/WavReader.h
+++ b/test/WavReader.h
@@ -20,13 +20,13 @@ struct ChunkInfo {
 };
 
 struct FmtChunk {
-    uint16_t audio_format;
-    uint16_t num_channels;
-    uint32_t sample_rate;
-    uint32_t byte_rate;
-    uint16_t block_align;
-    uint16_t bits_per_sample;
-    uint16_t extra_params_size;
+    uint16_t audio_format = 0;
+    uint16_t num_channels = 0;
+    uint32_t sample_rate = 0;
+    uint32_t byte_rate = 0;
+    uint16_t block_align = 0;
+    uint16_t bits_per_sample = 0;
+    uint16_t extra_params_size = 0;
     char* extra_params;
     FmtChunk() : extra_params{nullptr} {}
     FmtChunk(uint32_t chunk_size) : extra_params{new char[chunk_size - 18]} {}

--- a/test/scheduler/test_InferenceManager.cpp
+++ b/test/scheduler/test_InferenceManager.cpp
@@ -1,81 +1,93 @@
-#include <anira/anira.h>
-#include <anira/utils/helperFunctions.h>
-#include <stdint.h>
 
-#include <chrono>
-#include <thread>
+#include <anira/ContextConfig.h>
+#include <anira/InferenceConfig.h>
+#include <anira/PrePostProcessor.h>
+#include <anira/backends/BackendBase.h>
+#include <anira/scheduler/InferenceManager.h>
+#include <anira/utils/HostConfig.h>
+#include <anira/utils/InferenceBackend.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <iomanip>
+#include <ios>
+#include <ostream>
+#include <sstream>
+#include <string>
+#include <vector>
 
 #include "gtest/gtest.h"
 
 using namespace anira;
 
 struct InferenceManagerTestParams {
-    HostConfig host_config;
-    InferenceConfig inference_config;
-    std::vector<unsigned int> expected_latency;
+    HostConfig m_host_config;
+    InferenceConfig m_inference_config;
+    std::vector<unsigned int> m_expected_latency;
 };
 
+namespace {
 std::ostream& operator<<(std::ostream& stream, const InferenceManagerTestParams& params) {
     stream << "{ ";
     stream << "Host Config: { ";
-    stream << "host_buffer_size = " << params.host_config.m_buffer_size;
-    stream << ", host_sample_rate = " << params.host_config.m_sample_rate;
+    stream << "host_buffer_size = " << params.m_host_config.m_buffer_size;
+    stream << ", host_sample_rate = " << params.m_host_config.m_sample_rate;
     stream << " }, Inference Config: { ";
-    stream << "max_inference_time = " << params.inference_config.m_max_inference_time << " ms";
+    stream << "max_inference_time = " << params.m_inference_config.m_max_inference_time << " ms";
     stream << " }";
 
     return stream;
 }
+}  // namespace
 
 // // Test fixture for paramterized inference tests
 class InferenceManagerTest : public ::testing::TestWithParam<InferenceManagerTestParams> {};
 
 TEST_P(InferenceManagerTest, Simple) {
     auto test_params = GetParam();
-    auto buffer_size = test_params.host_config.m_buffer_size;
-    auto sample_rate = test_params.host_config.m_sample_rate;
 
-    PrePostProcessor pp_processor(test_params.inference_config);
+    PrePostProcessor pp_processor(test_params.m_inference_config);
     BackendBase* custom_processor = nullptr;  // Use default processor
-    ContextConfig context_config(2);  // Use 2 threads for testing, gh runner max on macOS is 3
+    ContextConfig const context_config(2);  // Use 2 threads for testing, gh runner max on macOS is
+                                            // 3
 
     InferenceManager inference_manager(pp_processor,
-                                       test_params.inference_config,
+                                       test_params.m_inference_config,
                                        custom_processor,
                                        context_config);
 
-    inference_manager.prepare(test_params.host_config);
+    inference_manager.prepare(test_params.m_host_config);
 
     std::vector<unsigned int> latency = inference_manager.get_latency();
 
-    for (size_t i = 0; i < test_params.expected_latency.size(); ++i) {
-        ASSERT_EQ(latency[i], test_params.expected_latency[i])
+    for (size_t i = 0; i < test_params.m_expected_latency.size(); ++i) {
+        ASSERT_EQ(latency[i], test_params.m_expected_latency[i])
             << "Latency mismatch for tensor " << i;
     }
 }
 
 TEST_P(InferenceManagerTest, WithCustomLatency) {
     auto test_params = GetParam();
-    auto buffer_size = test_params.host_config.m_buffer_size;
-    auto sample_rate = test_params.host_config.m_sample_rate;
 
-    PrePostProcessor pp_processor(test_params.inference_config);
+    PrePostProcessor pp_processor(test_params.m_inference_config);
     BackendBase* custom_processor = nullptr;  // Use default processor
-    ContextConfig context_config(2);  // Use 2 threads for testing, gh runner max on macOS is 3
+    ContextConfig const context_config(2);  // Use 2 threads for testing, gh runner max on macOS is
+                                            // 3
 
     InferenceManager inference_manager(pp_processor,
-                                       test_params.inference_config,
+                                       test_params.m_inference_config,
                                        custom_processor,
                                        context_config);
 
     // Create custom latency values - double the expected values for testing
     std::vector<long> custom_latency;
-    for (const auto& latency : test_params.expected_latency) {
-        custom_latency.push_back(latency * 2);
+    custom_latency.reserve(test_params.m_expected_latency.size());
+    for (const auto& latency : test_params.m_expected_latency) {
+        custom_latency.push_back(static_cast<long>(latency) * 2);
     }
 
     // Prepare with custom latency
-    inference_manager.prepare(test_params.host_config, custom_latency);
+    inference_manager.prepare(test_params.m_host_config, custom_latency);
 
     // Verify that the latency values match our custom ones
     std::vector<unsigned int> actual_latency = inference_manager.get_latency();
@@ -91,30 +103,29 @@ TEST_P(InferenceManagerTest, WithCustomLatency) {
 // Test with empty custom latency (should fall back to calculated values)
 TEST_P(InferenceManagerTest, WithEmptyCustomLatency) {
     auto test_params = GetParam();
-    auto buffer_size = test_params.host_config.m_buffer_size;
-    auto sample_rate = test_params.host_config.m_sample_rate;
 
-    PrePostProcessor pp_processor(test_params.inference_config);
+    PrePostProcessor pp_processor(test_params.m_inference_config);
     BackendBase* custom_processor = nullptr;  // Use default processor
-    ContextConfig context_config(2);  // Use 2 threads for testing, gh runner max on macOS is 3
+    ContextConfig const context_config(2);  // Use 2 threads for testing, gh runner max on macOS is
+                                            // 3
 
     InferenceManager inference_manager(pp_processor,
-                                       test_params.inference_config,
+                                       test_params.m_inference_config,
                                        custom_processor,
                                        context_config);
 
     // Prepare with empty custom latency vector
-    std::vector<long> empty_custom_latency;
-    inference_manager.prepare(test_params.host_config, empty_custom_latency);
+    std::vector<long> const empty_custom_latency;
+    inference_manager.prepare(test_params.m_host_config, empty_custom_latency);
 
     // Verify that the latency values match the expected calculated ones
     std::vector<unsigned int> actual_latency = inference_manager.get_latency();
 
-    ASSERT_EQ(actual_latency.size(), test_params.expected_latency.size())
+    ASSERT_EQ(actual_latency.size(), test_params.m_expected_latency.size())
         << "Latency vector size mismatch";
 
-    for (size_t i = 0; i < test_params.expected_latency.size(); ++i) {
-        ASSERT_EQ(actual_latency[i], test_params.expected_latency[i])
+    for (size_t i = 0; i < test_params.m_expected_latency.size(); ++i) {
+        ASSERT_EQ(actual_latency[i], test_params.m_expected_latency[i])
             << "Latency did not fall back to calculated value for tensor " << i;
     }
 }
@@ -122,36 +133,35 @@ TEST_P(InferenceManagerTest, WithEmptyCustomLatency) {
 // Test with partial custom latency (should use provided values and calculate the rest)
 TEST_P(InferenceManagerTest, WithPartialCustomLatency) {
     auto test_params = GetParam();
-    auto buffer_size = test_params.host_config.m_buffer_size;
-    auto sample_rate = test_params.host_config.m_sample_rate;
 
     // Skip test if we don't have at least 2 tensors
-    if (test_params.expected_latency.size() < 2) {
+    if (test_params.m_expected_latency.size() < 2) {
         GTEST_SKIP() << "Test requires at least 2 tensors to test partial custom latency";
         return;
     }
 
-    PrePostProcessor pp_processor(test_params.inference_config);
+    PrePostProcessor pp_processor(test_params.m_inference_config);
     BackendBase* custom_processor = nullptr;  // Use default processor
-    ContextConfig context_config(2);  // Use 2 threads for testing, gh runner max on macOS is 3
+    ContextConfig const context_config(2);  // Use 2 threads for testing, gh runner max on macOS is
+                                            // 3
 
     InferenceManager inference_manager(pp_processor,
-                                       test_params.inference_config,
+                                       test_params.m_inference_config,
                                        custom_processor,
                                        context_config);
 
     // Create partial custom latency (only for the first tensor)
-    std::vector<long> partial_custom_latency(test_params.expected_latency.size(), -1);
+    std::vector<long> partial_custom_latency(test_params.m_expected_latency.size(), -1);
     // Set a custom value for the first tensor
-    partial_custom_latency[0] = test_params.expected_latency[0] * 3;
+    partial_custom_latency[0] = static_cast<long>(test_params.m_expected_latency[0]) * 3;
 
     // Prepare with partial custom latency
-    inference_manager.prepare(test_params.host_config, partial_custom_latency);
+    inference_manager.prepare(test_params.m_host_config, partial_custom_latency);
 
     // Verify latency values
     std::vector<unsigned int> actual_latency = inference_manager.get_latency();
 
-    ASSERT_EQ(actual_latency.size(), test_params.expected_latency.size())
+    ASSERT_EQ(actual_latency.size(), test_params.m_expected_latency.size())
         << "Latency vector size mismatch";
 
     // First latency should be our custom value
@@ -159,33 +169,34 @@ TEST_P(InferenceManagerTest, WithPartialCustomLatency) {
         << "Custom latency not applied correctly for first tensor";
 
     // Remaining latencies should be calculated values
-    for (size_t i = 1; i < test_params.expected_latency.size(); ++i) {
-        ASSERT_EQ(actual_latency[i], test_params.expected_latency[i])
+    for (size_t i = 1; i < test_params.m_expected_latency.size(); ++i) {
+        ASSERT_EQ(actual_latency[i], test_params.m_expected_latency[i])
             << "Latency calculation incorrect for tensor " << i;
     }
 }
 
+namespace {
 std::string build_test_name(const testing::TestParamInfo<InferenceManagerTest::ParamType>& info) {
     std::stringstream ss_sample_rate, ss_buffer_size, ss_max_inference_time;
     std::vector<std::stringstream> ss_tensor_input_size, ss_tensor_output_size;
 
     // Set precision to 4 decimal places for cleaner names
-    ss_sample_rate << std::fixed << std::setprecision(4) << info.param.host_config.m_sample_rate;
-    ss_buffer_size << std::fixed << std::setprecision(4) << info.param.host_config.m_buffer_size;
+    ss_sample_rate << std::fixed << std::setprecision(4) << info.param.m_host_config.m_sample_rate;
+    ss_buffer_size << std::fixed << std::setprecision(4) << info.param.m_host_config.m_buffer_size;
     ss_max_inference_time << std::fixed << std::setprecision(2)
-                          << info.param.inference_config.m_max_inference_time;
+                          << info.param.m_inference_config.m_max_inference_time;
 
     std::stringstream ss;
     ss << "__input_size_";
-    for (const auto& size : info.param.inference_config.get_tensor_input_size()) {
-        ss_tensor_input_size.push_back(std::stringstream());
+    for (const auto& size : info.param.m_inference_config.get_tensor_input_size()) {
+        ss_tensor_input_size.emplace_back();
         ss_tensor_input_size.back() << size;
         ss << ss_tensor_input_size.back().str() << "_";
     }
 
     ss << "_output_size_";
-    for (const auto& size : info.param.inference_config.get_tensor_output_size()) {
-        ss_tensor_output_size.push_back(std::stringstream());
+    for (const auto& size : info.param.m_inference_config.get_tensor_output_size()) {
+        ss_tensor_output_size.emplace_back();
         ss_tensor_output_size.back() << size;
         ss << ss_tensor_output_size.back().str() << "_";
     }
@@ -193,16 +204,17 @@ std::string build_test_name(const testing::TestParamInfo<InferenceManagerTest::P
     std::string sample_rate_str = ss_sample_rate.str();
     std::string buffer_size_str = ss_buffer_size.str();
     std::string max_inference_time_str = ss_max_inference_time.str();
-    std::string tensor_shape_str = ss.str();
+    std::string const tensor_shape_str = ss.str();
 
     // Replace decimal points with underscores to make valid test names
-    std::replace(sample_rate_str.begin(), sample_rate_str.end(), '.', '_');
-    std::replace(buffer_size_str.begin(), buffer_size_str.end(), '.', '_');
-    std::replace(max_inference_time_str.begin(), max_inference_time_str.end(), '.', '_');
+    std::ranges::replace(sample_rate_str, '.', '_');
+    std::ranges::replace(buffer_size_str, '.', '_');
+    std::ranges::replace(max_inference_time_str, '.', '_');
 
     return "host_config_" + buffer_size_str + "x" + sample_rate_str + tensor_shape_str +
            "_max_time_" + max_inference_time_str;
 }
+}  // namespace
 
 INSTANTIATE_TEST_SUITE_P(
     CalculateLatency,

--- a/test/scheduler/test_SessionElement.cpp
+++ b/test/scheduler/test_SessionElement.cpp
@@ -1,26 +1,32 @@
-#include <anira/anira.h>
+#include <anira/InferenceConfig.h>
+#include <anira/PrePostProcessor.h>
 #include <anira/scheduler/SessionElement.h>
-#include <anira/utils/helperFunctions.h>
-#include <stdint.h>
+#include <anira/utils/HostConfig.h>
+#include <anira/utils/InferenceBackend.h>
 
-#include <chrono>
+#include <algorithm>
+#include <cstddef>
 #include <iomanip>
+#include <ios>
+#include <ostream>
 #include <sstream>
-#include <thread>
+#include <string>
+#include <vector>
 
 #include "gtest/gtest.h"
 
 using namespace anira;
 
 struct SessionElementTestParams {
-    HostConfig host_config;
-    InferenceConfig inference_config;
-    std::vector<unsigned int> expected_latency;
-    size_t expected_num_structs;
-    std::vector<size_t> expected_send_buffer_sizes;
-    std::vector<size_t> expected_receive_buffer_sizes;
+    HostConfig m_host_config;
+    InferenceConfig m_inference_config;
+    std::vector<unsigned int> m_expected_latency;
+    size_t m_expected_num_structs;
+    std::vector<size_t> m_expected_send_buffer_sizes;
+    std::vector<size_t> m_expected_receive_buffer_sizes;
 };
 
+namespace {
 template <typename T>
 std::ostream& operator<<(std::ostream& os, const std::vector<T>& vec) {
     os << "[ ";
@@ -32,19 +38,20 @@ std::ostream& operator<<(std::ostream& os, const std::vector<T>& vec) {
 std::ostream& operator<<(std::ostream& stream, const SessionElementTestParams& params) {
     stream << "{ ";
     stream << "Host Config: { ";
-    stream << "host_buffer_size = " << params.host_config.m_buffer_size;
-    stream << ", host_sample_rate = " << params.host_config.m_sample_rate;
-    stream << ", tensor_index = " << params.host_config.m_tensor_index;
+    stream << "host_buffer_size = " << params.m_host_config.m_buffer_size;
+    stream << ", host_sample_rate = " << params.m_host_config.m_sample_rate;
+    stream << ", tensor_index = " << params.m_host_config.m_tensor_index;
     stream << " }, Inference Config: { ";
-    stream << "max_inference_time = " << params.inference_config.m_max_inference_time << " ms";
-    stream << " }, Expected latency = " << params.expected_latency;
-    stream << ", Expected num_structs = " << params.expected_num_structs;
-    stream << ", Expected send buffer sizes = " << params.expected_send_buffer_sizes;
-    stream << ", Expected receive buffer sizes = " << params.expected_receive_buffer_sizes;
+    stream << "max_inference_time = " << params.m_inference_config.m_max_inference_time << " ms";
+    stream << " }, Expected latency = " << params.m_expected_latency;
+    stream << ", Expected num_structs = " << params.m_expected_num_structs;
+    stream << ", Expected send buffer sizes = " << params.m_expected_send_buffer_sizes;
+    stream << ", Expected receive buffer sizes = " << params.m_expected_receive_buffer_sizes;
     stream << " }";
 
     return stream;
 }
+}  // namespace
 
 // Test fixture for parameterized SessionElement tests
 class SessionElementTest : public ::testing::TestWithParam<SessionElementTestParams> {};
@@ -52,63 +59,65 @@ class SessionElementTest : public ::testing::TestWithParam<SessionElementTestPar
 TEST_P(SessionElementTest, LatencyStructAndRingbuffers) {
     auto test_params = GetParam();
 
-    PrePostProcessor pp_processor(test_params.inference_config);
+    PrePostProcessor pp_processor(test_params.m_inference_config);
 
     SessionElement session_element(0,  // session_id
                                    pp_processor,
-                                   test_params.inference_config);
+                                   test_params.m_inference_config);
 
-    session_element.prepare(test_params.host_config);
+    session_element.prepare(test_params.m_host_config);
 
-    for (size_t i = 0; i < test_params.expected_latency.size(); ++i) {
-        ASSERT_EQ(session_element.m_latency[i], test_params.expected_latency[i])
+    for (size_t i = 0; i < test_params.m_expected_latency.size(); ++i) {
+        ASSERT_EQ(session_element.m_latency[i], test_params.m_expected_latency[i])
             << "Latency mismatch at index " << i
-            << ". Expected: " << test_params.expected_latency[i]
+            << ". Expected: " << test_params.m_expected_latency[i]
             << ", Got: " << session_element.m_latency[i];
     }
 
-    ASSERT_EQ(session_element.m_num_structs, test_params.expected_num_structs)
-        << "Number of structs mismatch. Expected: " << test_params.expected_num_structs
+    ASSERT_EQ(session_element.m_num_structs, test_params.m_expected_num_structs)
+        << "Number of structs mismatch. Expected: " << test_params.m_expected_num_structs
         << ", Got: " << session_element.m_num_structs;
 
-    for (size_t i = 0; i < test_params.expected_send_buffer_sizes.size(); ++i) {
-        ASSERT_EQ(session_element.m_send_buffer_size[i], test_params.expected_send_buffer_sizes[i])
+    for (size_t i = 0; i < test_params.m_expected_send_buffer_sizes.size(); ++i) {
+        ASSERT_EQ(session_element.m_send_buffer_size[i],
+                  test_params.m_expected_send_buffer_sizes[i])
             << "Send buffer size mismatch at index " << i
-            << ". Expected: " << test_params.expected_send_buffer_sizes[i]
+            << ". Expected: " << test_params.m_expected_send_buffer_sizes[i]
             << ", Got: " << session_element.m_send_buffer_size[i];
     }
 
-    for (size_t i = 0; i < test_params.expected_receive_buffer_sizes.size(); ++i) {
+    for (size_t i = 0; i < test_params.m_expected_receive_buffer_sizes.size(); ++i) {
         ASSERT_EQ(session_element.m_receive_buffer_size[i],
-                  test_params.expected_receive_buffer_sizes[i])
+                  test_params.m_expected_receive_buffer_sizes[i])
             << "Receive buffer size mismatch at index " << i
-            << ". Expected: " << test_params.expected_receive_buffer_sizes[i]
+            << ". Expected: " << test_params.m_expected_receive_buffer_sizes[i]
             << ", Got: " << session_element.m_receive_buffer_size[i];
     }
 }
 
+namespace {
 std::string build_test_name(const testing::TestParamInfo<SessionElementTest::ParamType>& info) {
     std::stringstream ss_sample_rate, ss_buffer_size, ss_max_inference_time, ss_tensor_index;
     std::vector<std::stringstream> ss_tensor_input_size, ss_tensor_output_size;
 
     // Set precision to 4 decimal places for cleaner names
-    ss_sample_rate << std::fixed << std::setprecision(4) << info.param.host_config.m_sample_rate;
-    ss_buffer_size << std::fixed << std::setprecision(4) << info.param.host_config.m_buffer_size;
+    ss_sample_rate << std::fixed << std::setprecision(4) << info.param.m_host_config.m_sample_rate;
+    ss_buffer_size << std::fixed << std::setprecision(4) << info.param.m_host_config.m_buffer_size;
     ss_max_inference_time << std::fixed << std::setprecision(2)
-                          << info.param.inference_config.m_max_inference_time;
-    ss_tensor_index << info.param.host_config.m_tensor_index;
+                          << info.param.m_inference_config.m_max_inference_time;
+    ss_tensor_index << info.param.m_host_config.m_tensor_index;
 
     std::stringstream ss;
     ss << "__input_size_";
-    for (const auto& size : info.param.inference_config.get_tensor_input_size()) {
-        ss_tensor_input_size.push_back(std::stringstream());
+    for (const auto& size : info.param.m_inference_config.get_tensor_input_size()) {
+        ss_tensor_input_size.emplace_back();
         ss_tensor_input_size.back() << size;
         ss << ss_tensor_input_size.back().str() << "_";
     }
 
     ss << "_output_size_";
-    for (const auto& size : info.param.inference_config.get_tensor_output_size()) {
-        ss_tensor_output_size.push_back(std::stringstream());
+    for (const auto& size : info.param.m_inference_config.get_tensor_output_size()) {
+        ss_tensor_output_size.emplace_back();
         ss_tensor_output_size.back() << size;
         ss << ss_tensor_output_size.back().str() << "_";
     }
@@ -116,17 +125,18 @@ std::string build_test_name(const testing::TestParamInfo<SessionElementTest::Par
     std::string sample_rate_str = ss_sample_rate.str();
     std::string buffer_size_str = ss_buffer_size.str();
     std::string max_inference_time_str = ss_max_inference_time.str();
-    std::string tensor_index_str = ss_tensor_index.str();
-    std::string tensor_shape_str = ss.str();
+    std::string const tensor_index_str = ss_tensor_index.str();
+    std::string const tensor_shape_str = ss.str();
 
     // Replace decimal points with underscores to make valid test names
-    std::replace(sample_rate_str.begin(), sample_rate_str.end(), '.', '_');
-    std::replace(buffer_size_str.begin(), buffer_size_str.end(), '.', '_');
-    std::replace(max_inference_time_str.begin(), max_inference_time_str.end(), '.', '_');
+    std::ranges::replace(sample_rate_str, '.', '_');
+    std::ranges::replace(buffer_size_str, '.', '_');
+    std::ranges::replace(max_inference_time_str, '.', '_');
 
     return "host_config_" + buffer_size_str + "x" + sample_rate_str + "_tidx_" + tensor_index_str +
            tensor_shape_str + "_max_time_" + max_inference_time_str;
 }
+}  // namespace
 
 INSTANTIATE_TEST_SUITE_P(
     LatencyStructAndRingbuffers,

--- a/test/scheduler/test_UserManagedThread.cpp
+++ b/test/scheduler/test_UserManagedThread.cpp
@@ -1,6 +1,13 @@
-#include <anira/anira.h>
+
+#include <anira/ContextConfig.h>
+#include <anira/InferenceConfig.h>
+#include <anira/InferenceHandler.h>
+#include <anira/scheduler/Context.h>
+#include <anira/utils/Buffer.h>
+#include <anira/utils/InferenceBackend.h>
 
 #include <chrono>
+#include <cstddef>
 #include <thread>
 
 #include "../../extras/models/hybrid-nn/HybridNNBypassProcessor.h"
@@ -8,7 +15,7 @@
 #include "../../extras/models/hybrid-nn/HybridNNPrePostProcessor.h"
 #include "gtest/gtest.h"
 
-#define USER_THREAD_TIMEOUT_S 2
+constexpr int k_user_thread_timeout_s = 2;
 
 using namespace anira;
 
@@ -17,15 +24,15 @@ using namespace anira;
 // same pattern the wasm build uses under the hood (one JS Worker per
 // InferenceThread), now available natively as first-party.
 TEST(UserManagedInferenceThread, ProcessesAudioWithoutAutoPool) {
-    constexpr int buffer_size = 512;
-    constexpr double sample_rate = 44100.0;
+    constexpr int k_buffer_size = 512;
+    constexpr double k_sample_rate = 44100.0;
 
     InferenceConfig inference_config = hybridnn_config;
     HybridNNPrePostProcessor pp_processor(inference_config);
     HybridNNBypassProcessor bypass_processor(inference_config);
 
     // Zero auto-pool threads — the user owns the threading.
-    ContextConfig context_config(0);
+    ContextConfig const context_config(0);
 
     InferenceHandler inference_handler(pp_processor,
                                        inference_config,
@@ -36,21 +43,21 @@ TEST(UserManagedInferenceThread, ProcessesAudioWithoutAutoPool) {
     ASSERT_NE(user_thread, nullptr);
     user_thread->start();
 
-    inference_handler.prepare(HostConfig{buffer_size, sample_rate});
+    inference_handler.prepare(HostConfig{k_buffer_size, k_sample_rate});
     inference_handler.set_inference_backend(InferenceBackend::CUSTOM);
 
-    BufferF test_buffer(1, buffer_size);
-    for (size_t i = 0; i < buffer_size; ++i) {
-        test_buffer.set_sample(0, i, static_cast<float>(i) / buffer_size);
+    BufferF test_buffer(1, k_buffer_size);
+    for (size_t i = 0; i < k_buffer_size; ++i) {
+        test_buffer.set_sample(0, i, static_cast<float>(i) / k_buffer_size);
     }
 
     const size_t prev_samples = inference_handler.get_available_samples(0);
-    inference_handler.process(test_buffer.get_array_of_write_pointers(), buffer_size);
+    inference_handler.process(test_buffer.get_array_of_write_pointers(), k_buffer_size);
 
     auto start = std::chrono::system_clock::now();
     while (inference_handler.get_available_samples(0) == prev_samples) {
         if (std::chrono::system_clock::now() >
-            start + std::chrono::duration<long int>(USER_THREAD_TIMEOUT_S)) {
+            start + std::chrono::duration<long int>(k_user_thread_timeout_s)) {
             FAIL() << "User-managed inference thread did not process the block";
         }
         std::this_thread::sleep_for(std::chrono::microseconds(10));

--- a/test/test_InferenceHandler.cpp
+++ b/test/test_InferenceHandler.cpp
@@ -1,12 +1,24 @@
-#include <anira/anira.h>
-#include <anira/utils/helperFunctions.h>
-#include <stdint.h>
+
+#include <anira/ContextConfig.h>
+#include <anira/InferenceConfig.h>
+#include <anira/InferenceHandler.h>
+#include <anira/utils/Buffer.h>
+#include <anira/utils/HostConfig.h>
+#include <anira/utils/InferenceBackend.h>
+#include <anira/utils/RingBuffer.h>
 
 #include <algorithm>
+#include <cfloat>
 #include <chrono>
+#include <cstddef>
+#include <cstdlib>
 #include <iomanip>
+#include <ios>
+#include <ostream>
 #include <sstream>
+#include <string>
 #include <thread>
+#include <vector>
 
 #include "../extras/models/hybrid-nn/HybridNNBypassProcessor.h"  // Only needed for round trip test
 #include "../extras/models/hybrid-nn/HybridNNConfig.h"
@@ -14,22 +26,23 @@
 #include "WavReader.h"
 #include "gtest/gtest.h"
 
-#define INFERENCE_TIMEOUT_S 2
+constexpr int k_inference_timeout_s = 2;
 using namespace anira;
 
 struct InferenceTestParams {
-    InferenceBackend backend;
-    HostConfig host_config;
-    std::string input_data_path;
-    std::string reference_data_path;
-    size_t reference_data_offset;
-    float epsilon_rel = 1e-6f;
-    float epsilon_abs = 1e-7f;
+    InferenceBackend m_backend;
+    HostConfig m_host_config;
+    std::string m_input_data_path;
+    std::string m_reference_data_path;
+    size_t m_reference_data_offset;
+    float m_epsilon_rel = 1e-6f;
+    float m_epsilon_abs = 1e-7f;
 };
 
+namespace {
 std::ostream& operator<<(std::ostream& stream, const InferenceTestParams& params) {
     std::string backend;
-    switch (params.backend) {
+    switch (params.m_backend) {
 #ifdef USE_LIBTORCH
         case anira::InferenceBackend::LIBTORCH: backend = "libtorch"; break;
 #endif
@@ -46,33 +59,34 @@ std::ostream& operator<<(std::ostream& stream, const InferenceTestParams& params
 
     stream << "{ ";
     stream << "backend = " << backend;
-    stream << ", host_buffer_size = " << params.host_config.m_buffer_size;
-    stream << ", host_sample_rate = " << params.host_config.m_sample_rate;
+    stream << ", host_buffer_size = " << params.m_host_config.m_buffer_size;
+    stream << ", host_sample_rate = " << params.m_host_config.m_sample_rate;
     stream << " }";
 
     return stream;
 }
+}  // namespace
 
 // Test fixture for paramterized inference tests
 class InferenceTest : public ::testing::TestWithParam<InferenceTestParams> {};
 
 TEST_P(InferenceTest, Simple) {
     auto const& test_params = GetParam();
-    auto const& buffer_size = test_params.host_config.m_buffer_size;
-    auto const& reference_offset = test_params.reference_data_offset;
+    auto const buffer_size = static_cast<size_t>(test_params.m_host_config.m_buffer_size);
+    auto const& reference_offset = test_params.m_reference_data_offset;
 
     // read reference data
     std::vector<float> data_input;
     std::vector<float> data_reference;
 
-    read_wav(test_params.input_data_path, data_input);
-    read_wav(test_params.reference_data_path, data_reference);
+    read_wav(test_params.m_input_data_path, data_input);
+    read_wav(test_params.m_reference_data_path, data_reference);
 
     ASSERT_TRUE(data_input.size() > 0);
     ASSERT_TRUE(data_reference.size() > 0);
 
     // setup inference
-    ContextConfig anira_context_config;
+    ContextConfig const anira_context_config;
     InferenceConfig inference_config = hybridnn_config;
     HybridNNPrePostProcessor pp_processor(inference_config);
     HybridNNBypassProcessor bypass_processor(inference_config);
@@ -91,13 +105,17 @@ TEST_P(InferenceTest, Simple) {
                                        anira_context_config);
 
     // Allocate memory for audio processing
-    inference_handler.prepare(test_params.host_config);
+    inference_handler.prepare(test_params.m_host_config);
     // Select the inference backend
-    inference_handler.set_inference_backend(test_params.backend);
+    inference_handler.set_inference_backend(test_params.m_backend);
 
-    int latency_offset = inference_handler.get_latency();  // The 0th tensor is the audio data
-                                                           // tensor, so we only need the first
-                                                           // element of the latency vector
+    int const latency_offset = static_cast<int>(inference_handler.get_latency());  // The 0th tensor
+                                                                                   // is the audio
+                                                                                   // data tensor,
+                                                                                   // so we only
+                                                                                   // need the first
+                                                                                   // element of the
+                                                                                   // latency vector
 
     BufferF test_buffer(1, buffer_size);
     RingBuffer ring_buffer;
@@ -115,7 +133,7 @@ TEST_P(InferenceTest, Simple) {
             ring_buffer.push_sample(0, data_reference.at((repeat * buffer_size) + i));
         }
 
-        size_t prev_samples = inference_handler.get_available_samples(0);
+        size_t const prev_samples = inference_handler.get_available_samples(0);
 
         inference_handler.process(test_buffer.get_array_of_write_pointers(), buffer_size);
 
@@ -123,25 +141,26 @@ TEST_P(InferenceTest, Simple) {
         auto start = std::chrono::system_clock::now();
         while (inference_handler.get_available_samples(0) != prev_samples) {
             if (std::chrono::system_clock::now() >
-                start + std::chrono::duration<long int>(INFERENCE_TIMEOUT_S)) {
+                start + std::chrono::duration<long int>(k_inference_timeout_s)) {
                 FAIL() << "Timeout while waiting for block to be processed";
             }
             std::this_thread::sleep_for(std::chrono::nanoseconds(10));
         }
 
         for (size_t i = 0; i < buffer_size; i++) {
-            float reference = ring_buffer.pop_sample(0);
-            float processed = test_buffer.get_sample(0, i);
+            float const reference = ring_buffer.pop_sample(0);
+            float const processed = test_buffer.get_sample(0, i);
 
             if (repeat * buffer_size + i < latency_offset + reference_offset) {
                 ASSERT_FLOAT_EQ(reference, 0);
             } else {
                 // calculate epsilon on the fly
-                float epsilon = max(abs(reference), abs(processed)) * test_params.epsilon_rel +
-                                test_params.epsilon_abs;
+                float const epsilon =
+                    max(abs(reference), abs(processed)) * test_params.m_epsilon_rel +
+                    test_params.m_epsilon_abs;
                 ASSERT_NEAR(reference, processed, epsilon)
                     << "repeat=" << repeat << ", i=" << i
-                    << ", total sample nr: " << repeat * buffer_size + i << std::endl;
+                    << ", total sample nr: " << repeat * buffer_size + i << '\n';
             }
         }
     }
@@ -149,21 +168,21 @@ TEST_P(InferenceTest, Simple) {
 
 TEST_P(InferenceTest, WithCustomLatency) {
     auto const& test_params = GetParam();
-    auto const& buffer_size = test_params.host_config.m_buffer_size;
-    auto const& reference_offset = test_params.reference_data_offset;
+    auto const buffer_size = static_cast<size_t>(test_params.m_host_config.m_buffer_size);
+    auto const& reference_offset = test_params.m_reference_data_offset;
 
     // read reference data
     std::vector<float> data_input;
     std::vector<float> data_reference;
 
-    read_wav(test_params.input_data_path, data_input);
-    read_wav(test_params.reference_data_path, data_reference);
+    read_wav(test_params.m_input_data_path, data_input);
+    read_wav(test_params.m_reference_data_path, data_reference);
 
     ASSERT_TRUE(data_input.size() > 0);
     ASSERT_TRUE(data_reference.size() > 0);
 
     // setup inference
-    ContextConfig anira_context_config;
+    ContextConfig const anira_context_config;
     InferenceConfig inference_config = hybridnn_config;
     HybridNNPrePostProcessor pp_processor(inference_config);
     HybridNNBypassProcessor bypass_processor(inference_config);
@@ -182,13 +201,15 @@ TEST_P(InferenceTest, WithCustomLatency) {
                                        anira_context_config);
 
     // Allocate memory for audio processing
-    inference_handler.prepare(test_params.host_config, 0);
+    inference_handler.prepare(test_params.m_host_config, 0);
     // Select the inference backend
-    inference_handler.set_inference_backend(test_params.backend);
+    inference_handler.set_inference_backend(test_params.m_backend);
 
-    int latency = inference_handler.get_latency();  // The 0th tensor is the audio data tensor, so
-                                                    // we only need the first element of the latency
-                                                    // vector
+    int const latency = static_cast<int>(inference_handler.get_latency());  // The 0th tensor is the
+                                                                            // audio data tensor, so
+                                                                            // we only need the
+                                                                            // first element of the
+                                                                            // latency vector
 
     ASSERT_EQ(latency, 0) << "Custom latency should be set to 0 for this test";
 
@@ -206,7 +227,7 @@ TEST_P(InferenceTest, WithCustomLatency) {
             ring_buffer.push_sample(0, data_reference.at((repeat * buffer_size) + i));
         }
 
-        size_t prev_samples = inference_handler.get_available_samples(0);
+        size_t const prev_samples = inference_handler.get_available_samples(0);
 
         inference_handler.push_data(test_buffer.get_array_of_read_pointers(), buffer_size);
 
@@ -214,7 +235,7 @@ TEST_P(InferenceTest, WithCustomLatency) {
         auto start = std::chrono::system_clock::now();
         while (inference_handler.get_available_samples(0) != prev_samples + buffer_size) {
             if (std::chrono::system_clock::now() >
-                start + std::chrono::duration<long int>(INFERENCE_TIMEOUT_S)) {
+                start + std::chrono::duration<long int>(k_inference_timeout_s)) {
                 FAIL() << "Timeout while waiting for block to be processed";
             }
             std::this_thread::sleep_for(std::chrono::nanoseconds(10));
@@ -223,18 +244,19 @@ TEST_P(InferenceTest, WithCustomLatency) {
         inference_handler.pop_data(test_buffer.get_array_of_write_pointers(), buffer_size);
 
         for (size_t i = 0; i < buffer_size; i++) {
-            float reference = ring_buffer.pop_sample(0);
-            float processed = test_buffer.get_sample(0, i);
+            float const reference = ring_buffer.pop_sample(0);
+            float const processed = test_buffer.get_sample(0, i);
 
             if (repeat * buffer_size + i < reference_offset) {
                 ASSERT_FLOAT_EQ(reference, 0);
             } else {
                 // calculate epsilon on the fly
-                float epsilon = max(abs(reference), abs(processed)) * test_params.epsilon_rel +
-                                test_params.epsilon_abs;
+                float const epsilon =
+                    max(abs(reference), abs(processed)) * test_params.m_epsilon_rel +
+                    test_params.m_epsilon_abs;
                 ASSERT_NEAR(reference, processed, epsilon)
                     << "repeat=" << repeat << ", i=" << i
-                    << ", total sample nr: " << repeat * buffer_size + i << std::endl;
+                    << ", total sample nr: " << repeat * buffer_size + i << '\n';
             }
         }
     }
@@ -242,21 +264,21 @@ TEST_P(InferenceTest, WithCustomLatency) {
 
 TEST_P(InferenceTest, Reset) {
     auto const& test_params = GetParam();
-    auto const& buffer_size = test_params.host_config.m_buffer_size;
-    auto const& reference_offset = test_params.reference_data_offset;
+    auto const buffer_size = static_cast<size_t>(test_params.m_host_config.m_buffer_size);
+    auto const& reference_offset = test_params.m_reference_data_offset;
 
     // read reference data
     std::vector<float> data_input;
     std::vector<float> data_reference;
 
-    read_wav(test_params.input_data_path, data_input);
-    read_wav(test_params.reference_data_path, data_reference);
+    read_wav(test_params.m_input_data_path, data_input);
+    read_wav(test_params.m_reference_data_path, data_reference);
 
     ASSERT_TRUE(data_input.size() > 0);
     ASSERT_TRUE(data_reference.size() > 0);
 
     // setup inference
-    ContextConfig anira_context_config;
+    ContextConfig const anira_context_config;
     InferenceConfig inference_config = hybridnn_config;
     HybridNNPrePostProcessor pp_processor(inference_config);
     HybridNNBypassProcessor bypass_processor(inference_config);
@@ -275,13 +297,17 @@ TEST_P(InferenceTest, Reset) {
                                        anira_context_config);
 
     // Allocate memory for audio processing
-    inference_handler.prepare(test_params.host_config);
+    inference_handler.prepare(test_params.m_host_config);
     // Select the inference backend
-    inference_handler.set_inference_backend(test_params.backend);
+    inference_handler.set_inference_backend(test_params.m_backend);
 
-    int latency_offset = inference_handler.get_latency();  // The 0th tensor is the audio data
-                                                           // tensor, so we only need the first
-                                                           // element of the latency vector
+    int const latency_offset = static_cast<int>(inference_handler.get_latency());  // The 0th tensor
+                                                                                   // is the audio
+                                                                                   // data tensor,
+                                                                                   // so we only
+                                                                                   // need the first
+                                                                                   // element of the
+                                                                                   // latency vector
 
     BufferF test_buffer(1, buffer_size);
     RingBuffer ring_buffer;
@@ -299,32 +325,33 @@ TEST_P(InferenceTest, Reset) {
             ring_buffer.push_sample(0, data_reference.at((repeat * buffer_size) + i));
         }
 
-        size_t prev_samples = inference_handler.get_available_samples(0);
+        size_t const prev_samples = inference_handler.get_available_samples(0);
         inference_handler.process(test_buffer.get_array_of_write_pointers(), buffer_size);
 
         // wait until the block was properly processed
         auto start = std::chrono::system_clock::now();
         while (inference_handler.get_available_samples(0) != prev_samples) {
             if (std::chrono::system_clock::now() >
-                start + std::chrono::duration<long int>(INFERENCE_TIMEOUT_S)) {
+                start + std::chrono::duration<long int>(k_inference_timeout_s)) {
                 FAIL() << "Timeout while waiting for block to be processed";
             }
             std::this_thread::sleep_for(std::chrono::nanoseconds(10));
         }
 
         for (size_t i = 0; i < buffer_size; i++) {
-            float reference = ring_buffer.pop_sample(0);
-            float processed = test_buffer.get_sample(0, i);
+            float const reference = ring_buffer.pop_sample(0);
+            float const processed = test_buffer.get_sample(0, i);
 
             if (repeat * buffer_size + i < latency_offset + reference_offset) {
                 ASSERT_FLOAT_EQ(reference, 0);
             } else {
                 // calculate epsilon on the fly
-                float epsilon = max(abs(reference), abs(processed)) * test_params.epsilon_rel +
-                                test_params.epsilon_abs;
+                float const epsilon =
+                    max(abs(reference), abs(processed)) * test_params.m_epsilon_rel +
+                    test_params.m_epsilon_abs;
                 ASSERT_NEAR(reference, processed, epsilon)
                     << "repeat=" << repeat << ", i=" << i
-                    << ", total sample nr: " << repeat * buffer_size + i << std::endl;
+                    << ", total sample nr: " << repeat * buffer_size + i << '\n';
             }
         }
     }
@@ -352,7 +379,7 @@ TEST_P(InferenceTest, Reset) {
             ring_buffer.push_sample(0, data_reference.at((repeat * buffer_size) + i));
         }
 
-        size_t prev_samples = inference_handler.get_available_samples(0);
+        size_t const prev_samples = inference_handler.get_available_samples(0);
 
         inference_handler.process(test_buffer.get_array_of_write_pointers(), buffer_size);
 
@@ -360,46 +387,49 @@ TEST_P(InferenceTest, Reset) {
         auto start = std::chrono::system_clock::now();
         while (inference_handler.get_available_samples(0) != prev_samples) {
             if (std::chrono::system_clock::now() >
-                start + std::chrono::duration<long int>(INFERENCE_TIMEOUT_S)) {
+                start + std::chrono::duration<long int>(k_inference_timeout_s)) {
                 FAIL() << "Timeout while waiting for block to be processed";
             }
             std::this_thread::sleep_for(std::chrono::nanoseconds(10));
         }
 
         for (size_t i = 0; i < buffer_size; i++) {
-            float reference = ring_buffer.pop_sample(0);
-            float processed = test_buffer.get_sample(0, i);
+            float const reference = ring_buffer.pop_sample(0);
+            float const processed = test_buffer.get_sample(0, i);
 
             if (repeat * buffer_size + i < latency_offset + reference_offset) {
                 ASSERT_FLOAT_EQ(reference, 0);
             } else {
                 // calculate epsilon on the fly
-                float epsilon = max(abs(reference), abs(processed)) * test_params.epsilon_rel +
-                                test_params.epsilon_abs;
+                float const epsilon =
+                    max(abs(reference), abs(processed)) * test_params.m_epsilon_rel +
+                    test_params.m_epsilon_abs;
                 ASSERT_NEAR(reference, processed, epsilon)
                     << "After reset: repeat=" << repeat << ", i=" << i
-                    << ", total sample nr: " << repeat * buffer_size + i << std::endl;
+                    << ", total sample nr: " << repeat * buffer_size + i << '\n';
             }
         }
     }
 }
 
+namespace {
 std::string build_test_name(const testing::TestParamInfo<InferenceTest::ParamType>& info) {
     std::stringstream ss_sample_rate, ss_buffer_size;
 
     // Set precision to 4 decimal places for cleaner names
-    ss_sample_rate << std::fixed << std::setprecision(4) << info.param.host_config.m_sample_rate;
-    ss_buffer_size << std::fixed << std::setprecision(4) << info.param.host_config.m_buffer_size;
+    ss_sample_rate << std::fixed << std::setprecision(4) << info.param.m_host_config.m_sample_rate;
+    ss_buffer_size << std::fixed << std::setprecision(4) << info.param.m_host_config.m_buffer_size;
 
     std::string sample_rate_str = ss_sample_rate.str();
     std::string buffer_size_str = ss_buffer_size.str();
 
     // Replace decimal points with underscores to make valid test names
-    std::replace(sample_rate_str.begin(), sample_rate_str.end(), '.', '_');
-    std::replace(buffer_size_str.begin(), buffer_size_str.end(), '.', '_');
+    std::ranges::replace(sample_rate_str, '.', '_');
+    std::ranges::replace(buffer_size_str, '.', '_');
 
     return sample_rate_str + "x" + buffer_size_str;
 }
+}  // namespace
 
 INSTANTIATE_TEST_SUITE_P(
     InferenceBypass,

--- a/test/test_StatefulOrdering.cpp
+++ b/test/test_StatefulOrdering.cpp
@@ -1,7 +1,21 @@
-#include <anira/anira.h>
+
+#include <anira/ContextConfig.h>
+#include <anira/InferenceConfig.h>
+#include <anira/InferenceHandler.h>
+#include <anira/PrePostProcessor.h>
+#include <anira/backends/BackendBase.h>
+#include <anira/scheduler/SessionElement.h>
+#include <anira/utils/Buffer.h>
+#include <anira/utils/HostConfig.h>
+#include <anira/utils/InferenceBackend.h>
+#include <anira/utils/RingBuffer.h>
 
 #include <atomic>
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <iostream>
+#include <memory>
 #include <mutex>
 #include <thread>
 #include <vector>
@@ -21,25 +35,25 @@ class StatefulCounterBackend : public BackendBase {
 public:
     StatefulCounterBackend(InferenceConfig& config) : BackendBase(config) {}
 
-    void process(std::vector<BufferF>& input,
+    void process([[maybe_unused]] std::vector<BufferF>& input,
                  std::vector<BufferF>& output,
                  [[maybe_unused]] std::shared_ptr<SessionElement> session) override {
         // Small delay to increase the window for out-of-order dequeuing
         std::this_thread::sleep_for(std::chrono::microseconds(100));
 
-        int counter_val = m_counter.fetch_add(1);
+        int const counter_val = m_counter.fetch_add(1);
 
         // Write the counter value to all output samples
         for (size_t ch = 0; ch < output[0].get_num_channels(); ++ch) {
             float* write_ptr = output[0].get_write_pointer(ch);
-            size_t num_samples = output[0].get_num_samples();
+            size_t const num_samples = output[0].get_num_samples();
             for (size_t s = 0; s < num_samples; ++s) {
                 write_ptr[s] = static_cast<float>(counter_val);
             }
         }
 
         // Record the actual execution order
-        std::lock_guard<std::mutex> lock(m_order_mutex);
+        std::lock_guard<std::mutex> const lock(m_order_mutex);
         m_execution_order.push_back(counter_val);
     }
 
@@ -56,10 +70,10 @@ public:
     void pre_process(std::vector<RingBuffer>& input,
                      std::vector<BufferF>& output,
                      [[maybe_unused]] InferenceBackend current_inference_backend) override {
-        size_t num_samples = m_inference_config.get_preprocess_input_size()[0];
+        size_t const num_samples = m_inference_config.get_preprocess_input_size()[0];
         for (size_t ch = 0; ch < m_inference_config.get_preprocess_input_channels()[0]; ++ch) {
             for (size_t s = 0; s < num_samples; ++s) {
-                float sample = input[0].pop_sample(ch);
+                float const sample = input[0].pop_sample(ch);
                 output[0].set_sample(ch, s, sample);
             }
         }
@@ -68,7 +82,7 @@ public:
     void post_process(std::vector<BufferF>& input,
                       std::vector<RingBuffer>& output,
                       [[maybe_unused]] InferenceBackend current_inference_backend) override {
-        size_t num_samples = m_inference_config.get_postprocess_output_size()[0];
+        size_t const num_samples = m_inference_config.get_postprocess_output_size()[0];
         for (size_t ch = 0; ch < m_inference_config.get_postprocess_output_channels()[0]; ++ch) {
             for (size_t s = 0; s < num_samples; ++s) {
                 output[0].push_sample(ch, input[0].get_sample(ch, s));
@@ -82,10 +96,10 @@ public:
 // =============================================================================
 
 struct StatefulTestParams {
-    bool session_exclusive;
-    float host_buffer_size;
-    float sample_rate;
-    size_t hop_size;
+    bool m_session_exclusive;
+    float m_host_buffer_size;
+    float m_sample_rate;
+    size_t m_hop_size;
 };
 
 class StatefulOrderingTest : public ::testing::TestWithParam<StatefulTestParams> {};
@@ -95,25 +109,26 @@ TEST_P(StatefulOrderingTest, ExecutionOrder) {
 
     // Config: hop_size samples in, hop_size samples out, 1 channel
     // Host buffer > hop_size to force multiple inferences per callback
-    std::vector<ModelData> model_data = {ModelData("placeholder", InferenceBackend::CUSTOM)};
+    std::vector<ModelData> const model_data = {ModelData("placeholder", InferenceBackend::CUSTOM)};
 
-    std::vector<TensorShape> tensor_shape = {{{{1, 1, static_cast<int64_t>(params.hop_size)}},
-                                              {{1, 1, static_cast<int64_t>(params.hop_size)}}}};
+    std::vector<TensorShape> const tensor_shape = {
+        {{{1, 1, static_cast<int64_t>(params.m_hop_size)}},
+         {{1, 1, static_cast<int64_t>(params.m_hop_size)}}}};
 
-    ProcessingSpec processing_spec({1},                // preprocess_input_channels
-                                   {1},                // postprocess_output_channels
-                                   {params.hop_size},  // preprocess_input_size
-                                   {params.hop_size}   // postprocess_output_size
+    ProcessingSpec const processing_spec({1},                  // preprocess_input_channels
+                                         {1},                  // postprocess_output_channels
+                                         {params.m_hop_size},  // preprocess_input_size
+                                         {params.m_hop_size}   // postprocess_output_size
     );
 
     InferenceConfig config(model_data,
                            tensor_shape,
                            processing_spec,
-                           5.f,                                // max_inference_time ms
-                           0,                                  // warm_up
-                           params.session_exclusive,           // session_exclusive_processor
-                           0.0f,                               // blocking_ratio
-                           params.session_exclusive ? 1u : 4u  // num_parallel_processors
+                           5.f,                                  // max_inference_time ms
+                           0,                                    // warm_up
+                           params.m_session_exclusive,           // session_exclusive_processor
+                           0.0f,                                 // blocking_ratio
+                           params.m_session_exclusive ? 1u : 4u  // num_parallel_processors
     );
 
     PassthroughPrePostProcessor pp_processor(config);
@@ -125,21 +140,21 @@ TEST_P(StatefulOrderingTest, ExecutionOrder) {
 
     InferenceHandler handler(pp_processor, config, backend, context_config);
 
-    HostConfig host_config(params.host_buffer_size, params.sample_rate);
+    HostConfig const host_config(params.m_host_buffer_size, params.m_sample_rate);
     handler.prepare(host_config);
     handler.set_inference_backend(InferenceBackend::CUSTOM);
 
-    size_t buffer_size = static_cast<size_t>(params.host_buffer_size);
+    auto const buffer_size = static_cast<size_t>(params.m_host_buffer_size);
     BufferF test_buffer(1, buffer_size);
 
     // Simulate real-time audio callbacks at the correct pace
     auto callback_interval = std::chrono::microseconds(
-        static_cast<long long>(params.host_buffer_size / params.sample_rate * 1e6));
+        static_cast<long long>(params.m_host_buffer_size / params.m_sample_rate * 1e6));
 
-    constexpr size_t num_iterations = 300;
+    constexpr size_t k_num_iterations = 300;
     auto next_callback = std::chrono::steady_clock::now();
 
-    for (size_t iter = 0; iter < num_iterations; ++iter) {
+    for (size_t iter = 0; iter < k_num_iterations; ++iter) {
         for (size_t s = 0; s < buffer_size; ++s) { test_buffer.set_sample(0, s, 0.f); }
         handler.process(test_buffer.get_array_of_write_pointers(), buffer_size);
 
@@ -151,7 +166,7 @@ TEST_P(StatefulOrderingTest, ExecutionOrder) {
     std::this_thread::sleep_for(std::chrono::milliseconds(200));
 
     // Check execution order
-    std::lock_guard<std::mutex> lock(backend.m_order_mutex);
+    std::lock_guard<std::mutex> const lock(backend.m_order_mutex);
 
     ASSERT_GT(backend.m_execution_order.size(), 0u) << "No inferences were executed";
 
@@ -163,7 +178,7 @@ TEST_P(StatefulOrderingTest, ExecutionOrder) {
         }
     }
 
-    if (params.session_exclusive) {
+    if (params.m_session_exclusive) {
         // With session_exclusive_processor=true, execution MUST be in order
         EXPECT_TRUE(in_order)
             << "Session-exclusive processor is set but inferences executed out of order!"
@@ -172,7 +187,7 @@ TEST_P(StatefulOrderingTest, ExecutionOrder) {
         // Log whether out-of-order happened (for diagnostic purposes)
         std::cout << "session_exclusive=false: execution was "
                   << (in_order ? "IN ORDER (race not triggered)" : "OUT OF ORDER (race triggered)")
-                  << " (" << backend.m_execution_order.size() << " inferences)" << std::endl;
+                  << " (" << backend.m_execution_order.size() << " inferences)" << '\n';
     }
 }
 

--- a/test/test_WavReader.cpp
+++ b/test/test_WavReader.cpp
@@ -1,3 +1,7 @@
+#include <cstddef>
+#include <string>
+#include <vector>
+
 #include "WavReader.h"
 #include "gtest/gtest.h"
 

--- a/test/utils/test_Buffer.cpp
+++ b/test/utils/test_Buffer.cpp
@@ -1,4 +1,8 @@
-#include <anira/anira.h>
+#include <anira/utils/Buffer.h>
+#include <anira/utils/MemoryBlock.h>
+
+#include <cstddef>
+#include <string>
 
 #include "gtest/gtest.h"
 
@@ -12,7 +16,7 @@ TEST(Buffer, SimpleWrite) {
     buffer.set_sample(0, 5, 0.9f);
 
     for (size_t i = 0; i < buffer.get_num_samples(); i++) {
-        float expected = i == 5 ? 0.9f : 0.f;
+        float const expected = i == 5 ? 0.9f : 0.f;
         EXPECT_FLOAT_EQ(expected, buffer.get_sample(0, i));
     }
 
@@ -23,7 +27,7 @@ TEST(Buffer, SimpleWrite) {
 }
 
 TEST(Buffer, BlockSwap) {
-    int block_size = 10;
+    int const block_size = 10;
 
     MemoryBlock<int> block;
     anira::Buffer<int> buffer(1, block_size);
@@ -60,7 +64,7 @@ TEST(Buffer, BlockSwap) {
 }
 
 TEST(Buffer, BufferSwap) {
-    int block_size = 10;
+    int const block_size = 10;
 
     anira::Buffer<int> buffer1(1, block_size);
     anira::Buffer<int> buffer2(1, block_size);
@@ -102,7 +106,7 @@ TEST(Buffer, InvalidSizeSwap) {
     testing::internal::CaptureStderr();
     buffer1.swap_data(buffer2);
 
-    std::string output = testing::internal::GetCapturedStderr();
+    std::string const output = testing::internal::GetCapturedStderr();
 
     // check that the blocks were actually swapped
     ASSERT_EQ(buffer1_ptr, buffer1.data());
@@ -121,7 +125,7 @@ TEST(Buffer, InvalidChannelsSwap) {
     testing::internal::CaptureStderr();
     buffer1.swap_data(buffer2);
 
-    std::string output = testing::internal::GetCapturedStderr();
+    std::string const output = testing::internal::GetCapturedStderr();
 
     // check that the blocks were actually swapped
     ASSERT_EQ(buffer1_ptr, buffer1.data());

--- a/test/utils/test_JsonConfigLoader.cpp
+++ b/test/utils/test_JsonConfigLoader.cpp
@@ -1,4 +1,10 @@
-#include <anira/anira.h>
+#include <anira/InferenceConfig.h>
+#include <anira/utils/JsonConfigLoader.h>
+
+#include <array>
+#include <cstddef>
+#include <cstring>
+#include <vector>
 
 #include "gtest/gtest.h"
 
@@ -12,6 +18,8 @@
 #include "../../extras/models/third-party/ircam-acids/RaveFunkDrumConfigEncoder.h"
 
 using namespace anira;
+
+namespace {
 
 void expect_inference_config_eq(const InferenceConfig& a, const InferenceConfig& b) {
     // High level comparison
@@ -79,6 +87,8 @@ void expect_inference_config_eq(const InferenceConfig& a, const InferenceConfig&
     // Final check using the equality operator
     EXPECT_EQ(a, b);
 }
+
+}  // namespace
 
 // Test basic initialization
 TEST(JsonConfigLoader, EqualInferenceConfig) {

--- a/test/utils/test_RingBuffer.cpp
+++ b/test/utils/test_RingBuffer.cpp
@@ -1,4 +1,9 @@
-#include <anira/anira.h>
+#include <anira/utils/Buffer.h>
+#include <anira/utils/RingBuffer.h>
+
+#include <array>
+#include <cstddef>
+#include <string>
 
 #include "gtest/gtest.h"
 
@@ -8,73 +13,73 @@ class RingBufferTest : public ::testing::Test {
 protected:
     void SetUp() override {
         // Set up a 2-channel, 5-sample ring buffer for most tests
-        ring_buffer.initialize_with_positions(2, 5);
+        m_ring_buffer.initialize_with_positions(2, 5);
     }
 
     void TearDown() override {
         // Clean up after each test
     }
 
-    RingBuffer ring_buffer;
+    RingBuffer m_ring_buffer;
 };
 
 // Test basic initialization
 TEST_F(RingBufferTest, Initialization) {
-    EXPECT_EQ(ring_buffer.get_num_channels(), 2);
-    EXPECT_EQ(ring_buffer.get_num_samples(), 5);
+    EXPECT_EQ(m_ring_buffer.get_num_channels(), 2);
+    EXPECT_EQ(m_ring_buffer.get_num_samples(), 5);
 
     // All channels should start empty
-    for (size_t channel = 0; channel < ring_buffer.get_num_channels(); ++channel) {
-        EXPECT_EQ(ring_buffer.get_available_samples(channel), 0);
-        EXPECT_EQ(ring_buffer.get_available_past_samples(channel), 5);
+    for (size_t channel = 0; channel < m_ring_buffer.get_num_channels(); ++channel) {
+        EXPECT_EQ(m_ring_buffer.get_available_samples(channel), 0);
+        EXPECT_EQ(m_ring_buffer.get_available_past_samples(channel), 5);
     }
 }
 
 // Test single channel push and pop operations
 TEST_F(RingBufferTest, SingleChannelPushPop) {
     const size_t channel = 0;
-    const float test_values[] = {1.0f, 2.0f, 3.0f};
+    const std::array<float, 3> test_values = {1.0f, 2.0f, 3.0f};
 
     // Push some samples
-    for (float value : test_values) { ring_buffer.push_sample(channel, value); }
+    for (float const value : test_values) { m_ring_buffer.push_sample(channel, value); }
 
-    EXPECT_EQ(ring_buffer.get_available_samples(channel), 3);
+    EXPECT_EQ(m_ring_buffer.get_available_samples(channel), 3);
 
     // Pop samples and verify they come out in FIFO order
-    for (float expected_value : test_values) {
-        float popped_value = ring_buffer.pop_sample(channel);
+    for (float const expected_value : test_values) {
+        float const popped_value = m_ring_buffer.pop_sample(channel);
         EXPECT_FLOAT_EQ(popped_value, expected_value);
     }
 
-    EXPECT_EQ(ring_buffer.get_available_samples(channel), 0);
+    EXPECT_EQ(m_ring_buffer.get_available_samples(channel), 0);
 }
 
 // Test multi-channel operations
 TEST_F(RingBufferTest, MultiChannelOperations) {
-    const float channel0_values[] = {1.0f, 2.0f, 3.0f};
-    const float channel1_values[] = {10.0f, 20.0f, 30.0f};
+    const std::array<float, 3> channel0_values = {1.0f, 2.0f, 3.0f};
+    const std::array<float, 3> channel1_values = {10.0f, 20.0f, 30.0f};
 
     // Push samples to both channels
     for (size_t i = 0; i < 3; ++i) {
-        ring_buffer.push_sample(0, channel0_values[i]);
-        ring_buffer.push_sample(1, channel1_values[i]);
+        m_ring_buffer.push_sample(0, channel0_values[i]);
+        m_ring_buffer.push_sample(1, channel1_values[i]);
     }
 
     // Verify available samples for both channels
-    EXPECT_EQ(ring_buffer.get_available_samples(0), 3);
-    EXPECT_EQ(ring_buffer.get_available_samples(1), 3);
+    EXPECT_EQ(m_ring_buffer.get_available_samples(0), 3);
+    EXPECT_EQ(m_ring_buffer.get_available_samples(1), 3);
 
     // Pop from channel 0 and verify channel 1 is unaffected
-    float popped = ring_buffer.pop_sample(0);
+    float popped = m_ring_buffer.pop_sample(0);
     EXPECT_FLOAT_EQ(popped, 1.0f);
-    EXPECT_EQ(ring_buffer.get_available_samples(0), 2);
-    EXPECT_EQ(ring_buffer.get_available_samples(1), 3);
+    EXPECT_EQ(m_ring_buffer.get_available_samples(0), 2);
+    EXPECT_EQ(m_ring_buffer.get_available_samples(1), 3);
 
     // Pop from channel 1 and verify
-    popped = ring_buffer.pop_sample(1);
+    popped = m_ring_buffer.pop_sample(1);
     EXPECT_FLOAT_EQ(popped, 10.0f);
-    EXPECT_EQ(ring_buffer.get_available_samples(0), 2);
-    EXPECT_EQ(ring_buffer.get_available_samples(1), 2);
+    EXPECT_EQ(m_ring_buffer.get_available_samples(0), 2);
+    EXPECT_EQ(m_ring_buffer.get_available_samples(1), 2);
 }
 
 // Test buffer overflow behavior
@@ -82,27 +87,27 @@ TEST_F(RingBufferTest, BufferOverflow) {
     const size_t channel = 0;
 
     // Fill the buffer completely (5 samples)
-    for (int i = 1; i <= 5; ++i) { ring_buffer.push_sample(channel, static_cast<float>(i)); }
+    for (int i = 1; i <= 5; ++i) { m_ring_buffer.push_sample(channel, static_cast<float>(i)); }
 
-    EXPECT_EQ(ring_buffer.get_available_samples(channel), 5);
+    EXPECT_EQ(m_ring_buffer.get_available_samples(channel), 5);
 
     // Capture stderr to check for overflow error
     testing::internal::CaptureStderr();
 
     // Push one more sample (should cause overflow)
-    ring_buffer.push_sample(channel, 6.0f);
+    m_ring_buffer.push_sample(channel, 6.0f);
 
-    std::string output = testing::internal::GetCapturedStderr();
+    std::string const output = testing::internal::GetCapturedStderr();
     EXPECT_TRUE(output.find("Buffer overflow detected") != std::string::npos);
 
     // Buffer should still be full
-    EXPECT_EQ(ring_buffer.get_available_samples(channel), 5);
+    EXPECT_EQ(m_ring_buffer.get_available_samples(channel), 5);
 
     // The oldest sample (1.0f) should have been overwritten
     // So we should get 2.0f, 3.0f, 4.0f, 5.0f, 6.0f
-    float expected_values[] = {2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
-    for (float expected : expected_values) {
-        float popped = ring_buffer.pop_sample(channel);
+    std::array<float, 5> const expected_values = {2.0f, 3.0f, 4.0f, 5.0f, 6.0f};
+    for (float const expected : expected_values) {
+        float const popped = m_ring_buffer.pop_sample(channel);
         EXPECT_FLOAT_EQ(popped, expected);
     }
 }
@@ -114,9 +119,9 @@ TEST_F(RingBufferTest, PopFromEmptyBuffer) {
     // Capture stderr to check for empty buffer error
     testing::internal::CaptureStderr();
 
-    float popped = ring_buffer.pop_sample(channel);
+    float const popped = m_ring_buffer.pop_sample(channel);
 
-    std::string output = testing::internal::GetCapturedStderr();
+    std::string const output = testing::internal::GetCapturedStderr();
     EXPECT_TRUE(output.find("Attempted to pop sample from empty buffer") != std::string::npos);
     EXPECT_FLOAT_EQ(popped, 0.0f);
 }
@@ -124,15 +129,15 @@ TEST_F(RingBufferTest, PopFromEmptyBuffer) {
 // Test get_future_sample with offset
 TEST_F(RingBufferTest, GetSampleWithOffset) {
     const size_t channel = 0;
-    const float test_values[] = {1.0f, 2.0f, 3.0f};
+    const std::array<float, 3> test_values = {1.0f, 2.0f, 3.0f};
 
     // Push some samples
-    for (float value : test_values) { ring_buffer.push_sample(channel, value); }
+    for (float const value : test_values) { m_ring_buffer.push_sample(channel, value); }
 
     // Test getting samples with different offsets
-    EXPECT_FLOAT_EQ(ring_buffer.get_future_sample(channel, 0), 1.0f);  // First sample
-    EXPECT_FLOAT_EQ(ring_buffer.get_future_sample(channel, 1), 2.0f);  // Second sample
-    EXPECT_FLOAT_EQ(ring_buffer.get_future_sample(channel, 2), 3.0f);  // Third sample
+    EXPECT_FLOAT_EQ(m_ring_buffer.get_future_sample(channel, 0), 1.0f);  // First sample
+    EXPECT_FLOAT_EQ(m_ring_buffer.get_future_sample(channel, 1), 2.0f);  // Second sample
+    EXPECT_FLOAT_EQ(m_ring_buffer.get_future_sample(channel, 2), 3.0f);  // Third sample
 }
 
 // Test get_future_sample with invalid offset
@@ -140,15 +145,15 @@ TEST_F(RingBufferTest, GetSampleInvalidOffset) {
     const size_t channel = 0;
 
     // Push only one sample
-    ring_buffer.push_sample(channel, 1.0f);
+    m_ring_buffer.push_sample(channel, 1.0f);
 
     // Capture stderr to check for invalid offset error
     testing::internal::CaptureStderr();
 
     // Try to get sample with offset beyond available samples
-    float sample = ring_buffer.get_future_sample(channel, 5);
+    float const sample = m_ring_buffer.get_future_sample(channel, 5);
 
-    std::string output = testing::internal::GetCapturedStderr();
+    std::string const output = testing::internal::GetCapturedStderr();
     EXPECT_TRUE(output.find("Attempted to get sample with offset") != std::string::npos);
     EXPECT_FLOAT_EQ(sample, 0.0f);
 }
@@ -156,25 +161,25 @@ TEST_F(RingBufferTest, GetSampleInvalidOffset) {
 // Test get_past_sample functionality
 TEST_F(RingBufferTest, GetPastSample) {
     const size_t channel = 0;
-    const float test_values[] = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
+    const std::array<float, 5> test_values = {1.0f, 2.0f, 3.0f, 4.0f, 5.0f};
 
     // Push and then pop some samples to create past samples
-    for (float value : test_values) { ring_buffer.push_sample(channel, value); }
+    for (float const value : test_values) { m_ring_buffer.push_sample(channel, value); }
 
     // Pop first two samples
-    ring_buffer.pop_sample(channel);  // Pop 1.0f
-    ring_buffer.pop_sample(channel);  // Pop 2.0f
+    m_ring_buffer.pop_sample(channel);  // Pop 1.0f
+    m_ring_buffer.pop_sample(channel);  // Pop 2.0f
 
     // Now we should have 3.0f, 4.0f, 5.0f in the buffer
-    EXPECT_FLOAT_EQ(ring_buffer.get_past_sample(channel, 0), 3.0f);  // Current sample
-    EXPECT_FLOAT_EQ(ring_buffer.get_past_sample(channel, 1), 2.0f);
-    EXPECT_FLOAT_EQ(ring_buffer.get_past_sample(channel, 2), 1.0f);
+    EXPECT_FLOAT_EQ(m_ring_buffer.get_past_sample(channel, 0), 3.0f);  // Current sample
+    EXPECT_FLOAT_EQ(m_ring_buffer.get_past_sample(channel, 1), 2.0f);
+    EXPECT_FLOAT_EQ(m_ring_buffer.get_past_sample(channel, 2), 1.0f);
 
     // Capture stderr to check for past sample retrieval
     testing::internal::CaptureStderr();
-    EXPECT_FLOAT_EQ(ring_buffer.get_past_sample(channel, 3), 0.0f);  // No sample available
+    EXPECT_FLOAT_EQ(m_ring_buffer.get_past_sample(channel, 3), 0.0f);  // No sample available
 
-    std::string output = testing::internal::GetCapturedStderr();
+    std::string const output = testing::internal::GetCapturedStderr();
     EXPECT_TRUE(output.find("RingBuffer: Attempted to get past sample with offset") !=
                 std::string::npos);
 }
@@ -184,22 +189,22 @@ TEST_F(RingBufferTest, CircularWrapAround) {
     const size_t channel = 0;
 
     // Fill buffer completely
-    for (int i = 1; i <= 5; ++i) { ring_buffer.push_sample(channel, static_cast<float>(i)); }
+    for (int i = 1; i <= 5; ++i) { m_ring_buffer.push_sample(channel, static_cast<float>(i)); }
 
     // Pop some samples
-    EXPECT_FLOAT_EQ(ring_buffer.pop_sample(channel), 1.0f);
-    EXPECT_FLOAT_EQ(ring_buffer.pop_sample(channel), 2.0f);
+    EXPECT_FLOAT_EQ(m_ring_buffer.pop_sample(channel), 1.0f);
+    EXPECT_FLOAT_EQ(m_ring_buffer.pop_sample(channel), 2.0f);
 
     // Push more samples (should wrap around)
-    ring_buffer.push_sample(channel, 6.0f);
-    ring_buffer.push_sample(channel, 7.0f);
+    m_ring_buffer.push_sample(channel, 6.0f);
+    m_ring_buffer.push_sample(channel, 7.0f);
 
     // Verify the remaining samples
-    EXPECT_FLOAT_EQ(ring_buffer.pop_sample(channel), 3.0f);
-    EXPECT_FLOAT_EQ(ring_buffer.pop_sample(channel), 4.0f);
-    EXPECT_FLOAT_EQ(ring_buffer.pop_sample(channel), 5.0f);
-    EXPECT_FLOAT_EQ(ring_buffer.pop_sample(channel), 6.0f);
-    EXPECT_FLOAT_EQ(ring_buffer.pop_sample(channel), 7.0f);
+    EXPECT_FLOAT_EQ(m_ring_buffer.pop_sample(channel), 3.0f);
+    EXPECT_FLOAT_EQ(m_ring_buffer.pop_sample(channel), 4.0f);
+    EXPECT_FLOAT_EQ(m_ring_buffer.pop_sample(channel), 5.0f);
+    EXPECT_FLOAT_EQ(m_ring_buffer.pop_sample(channel), 6.0f);
+    EXPECT_FLOAT_EQ(m_ring_buffer.pop_sample(channel), 7.0f);
 }
 
 // Test clear_with_positions
@@ -207,22 +212,22 @@ TEST_F(RingBufferTest, ClearWithPositions) {
     const size_t channel = 0;
 
     // Add some samples
-    ring_buffer.push_sample(channel, 1.0f);
-    ring_buffer.push_sample(channel, 2.0f);
-    ring_buffer.push_sample(channel, 3.0f);
+    m_ring_buffer.push_sample(channel, 1.0f);
+    m_ring_buffer.push_sample(channel, 2.0f);
+    m_ring_buffer.push_sample(channel, 3.0f);
 
-    EXPECT_EQ(ring_buffer.get_available_samples(channel), 3);
+    EXPECT_EQ(m_ring_buffer.get_available_samples(channel), 3);
 
     // Clear the buffer
-    ring_buffer.clear_with_positions();
+    m_ring_buffer.clear_with_positions();
 
     // Buffer should be empty
-    EXPECT_EQ(ring_buffer.get_available_samples(channel), 0);
-    EXPECT_EQ(ring_buffer.get_available_past_samples(channel), 5);
+    EXPECT_EQ(m_ring_buffer.get_available_samples(channel), 0);
+    EXPECT_EQ(m_ring_buffer.get_available_past_samples(channel), 5);
 
     // All samples should be zero
-    for (size_t i = 0; i < ring_buffer.get_num_samples(); ++i) {
-        EXPECT_FLOAT_EQ(ring_buffer.Buffer<float>::get_sample(channel, i), 0.0f);
+    for (size_t i = 0; i < m_ring_buffer.get_num_samples(); ++i) {
+        EXPECT_FLOAT_EQ(m_ring_buffer.Buffer<float>::get_sample(channel, i), 0.0f);
     }
 }
 
@@ -231,24 +236,24 @@ TEST_F(RingBufferTest, AvailableSamplesCalculation) {
     const size_t channel = 0;
 
     // Initially empty
-    EXPECT_EQ(ring_buffer.get_available_samples(channel), 0);
-    EXPECT_EQ(ring_buffer.get_available_past_samples(channel), 5);
+    EXPECT_EQ(m_ring_buffer.get_available_samples(channel), 0);
+    EXPECT_EQ(m_ring_buffer.get_available_past_samples(channel), 5);
 
     // Add samples one by one and check available count
     for (int i = 1; i <= 5; ++i) {
-        ring_buffer.push_sample(channel, static_cast<float>(i));
-        EXPECT_EQ(ring_buffer.get_available_samples(channel), i);
-        EXPECT_EQ(ring_buffer.get_available_past_samples(channel), 5 - i);
+        m_ring_buffer.push_sample(channel, static_cast<float>(i));
+        EXPECT_EQ(m_ring_buffer.get_available_samples(channel), i);
+        EXPECT_EQ(m_ring_buffer.get_available_past_samples(channel), 5 - i);
     }
 
     // Buffer is now full
-    EXPECT_EQ(ring_buffer.get_available_samples(channel), 5);
-    EXPECT_EQ(ring_buffer.get_available_past_samples(channel), 0);
+    EXPECT_EQ(m_ring_buffer.get_available_samples(channel), 5);
+    EXPECT_EQ(m_ring_buffer.get_available_past_samples(channel), 0);
 
     // Pop samples and check count decreases
     for (int i = 4; i >= 0; --i) {
-        ring_buffer.pop_sample(channel);
-        EXPECT_EQ(ring_buffer.get_available_samples(channel), i);
+        m_ring_buffer.pop_sample(channel);
+        EXPECT_EQ(m_ring_buffer.get_available_samples(channel), i);
     }
 }
 
@@ -271,7 +276,7 @@ TEST(RingBufferSingleSample, EdgeCases) {
 
     testing::internal::CaptureStderr();
     small_buffer.push_sample(channel, 2.0f);  // Should overflow
-    std::string output = testing::internal::GetCapturedStderr();
+    std::string const output = testing::internal::GetCapturedStderr();
     EXPECT_TRUE(output.find("Buffer overflow detected") != std::string::npos);
 
     // Should get the newer value
@@ -292,23 +297,23 @@ TEST(RingBufferZeroSize, EdgeCase) {
     // Pushing to zero-sized buffer should be handled
     testing::internal::CaptureStderr();
     zero_buffer.push_sample(channel, 1.0f);
-    std::string output = testing::internal::GetCapturedStderr();
+    testing::internal::GetCapturedStderr();
     // May or may not produce an error, depends on implementation
 }
 
 // Test inheritance from Buffer<float>
 TEST_F(RingBufferTest, BufferInheritance) {
     // Test that RingBuffer still provides Buffer functionality
-    EXPECT_EQ(ring_buffer.get_num_channels(), 2);
-    EXPECT_EQ(ring_buffer.get_num_samples(), 5);
+    EXPECT_EQ(m_ring_buffer.get_num_channels(), 2);
+    EXPECT_EQ(m_ring_buffer.get_num_samples(), 5);
 
     // Test direct access to underlying buffer (inherited methods)
-    ring_buffer.Buffer<float>::set_sample(0, 0, 99.0f);
-    EXPECT_FLOAT_EQ(ring_buffer.Buffer<float>::get_sample(0, 0), 99.0f);
+    m_ring_buffer.Buffer<float>::set_sample(0, 0, 99.0f);
+    EXPECT_FLOAT_EQ(m_ring_buffer.Buffer<float>::get_sample(0, 0), 99.0f);
 
     // Test that we can get pointers to the data
-    float* write_ptr = ring_buffer.get_write_pointer(0);
-    const float* read_ptr = ring_buffer.get_read_pointer(0);
+    float* write_ptr = m_ring_buffer.get_write_pointer(0);
+    const float* read_ptr = m_ring_buffer.get_read_pointer(0);
     EXPECT_NE(write_ptr, nullptr);
     EXPECT_NE(read_ptr, nullptr);
     EXPECT_EQ(write_ptr, read_ptr);  // Should point to same location

--- a/test/utils/test_Semaphore.cpp
+++ b/test/utils/test_Semaphore.cpp
@@ -1,4 +1,5 @@
-#include <anira/anira.h>
+
+#include <anira/utils/Semaphore.h>
 
 #include <chrono>
 
@@ -44,16 +45,16 @@ TEST(SemaphoreTest, AcquireReturnsWhenPermitAvailable) {
 // for approximately the requested timeout before giving up.
 TEST(SemaphoreTest, TryAcquireUntilTimesOut) {
     Semaphore sem{0};
-    constexpr auto timeout = std::chrono::milliseconds(20);
+    constexpr auto k_timeout = std::chrono::milliseconds(20);
 
     const auto start = std::chrono::steady_clock::now();
-    const bool acquired = sem.try_acquire_until(start + timeout);
+    const bool acquired = sem.try_acquire_until(start + k_timeout);
     const auto elapsed = std::chrono::steady_clock::now() - start;
 
     EXPECT_FALSE(acquired);
     // It should have waited at least most of the timeout. Allow a small slack
     // to tolerate timer granularity / early wakeups across platforms.
-    EXPECT_GE(elapsed, timeout - std::chrono::milliseconds(5));
+    EXPECT_GE(elapsed, k_timeout - std::chrono::milliseconds(5));
 }
 
 // try_acquire_until succeeds immediately when a permit is available, well


### PR DESCRIPTION
Closes #69

Makes the library, tests and benchmark sources **clang-tidy conformant** (using the `.clang-tidy` config symlinked from the `tanh-lib` submodule) and enforces it in CI, mirroring the clang-format work in #70.

Starting point was ~1636 raw warnings (~567 unique); the branch now reports **0 warnings** under `--warnings-as-errors='*'`, all **208 tests pass**, and clang-format stays clean.

## Changes
- **Mechanical fixes**: `performance-avoid-endl`, `misc-const-correctness`, `modernize-*`, `bugprone-narrowing-conversions` (explicit `static_cast`, arithmetic preserved), `misc-include-cleaner` (normalized to the project's `<anira/...>` include style), `performance-unnecessary-value-param`/`modernize-pass-by-value`, C-arrays → `std::array`, anonymous namespaces, unused parameters, dead-store removal, recursive GCD → iterative.
- **Include cycle broken**: `SessionElement.h` now only forward-declares the backend processors (held via `shared_ptr`); the `.cpp` files that call processor methods include them directly (`// IWYU pragma: keep`).
- **Bug fix**: potential use-after-free in `Buffer::malloc_channels()` when the channel-pointer allocation fails.
- `Context.h` queue-sizing macros → `constexpr` constants; `helperFunctions.h` `calculate_min`/`calculate_max` lambdas → `inline` functions.

## API impact
The only **breaking** change is renaming the `InferenceConfig::Defaults` compile-time constants from the `m_` prefix to `k_` (`m_warm_up` → `k_warm_up`, `m_session_exclusive_processor` → `k_session_exclusive_processor`, `m_blocking_ratio` → `k_blocking_ratio`); `Defaults::m_num_parallel_processors` (mutable) is unchanged. All other public-facing changes are source-compatible. See the CHANGELOG.

## CI
Adds `.github/workflows/clang_tidy.yml` using `tanh-lab/ci-actions/clang-tidy-check@main`, plus a dedicated `clang-tidy` CMake preset (tests + benchmark + all backends) that the workflow builds before analysis.

## Not covered (follow-up)
- `src/emscripten-wrappers/` (only build under the Emscripten/wasm toolchain, so absent from this build's compilation database — explicitly excluded from `SOURCES`).
- The JUCE/CLAP examples.