### PR TITLE
fix: pooled processor dangling InferenceConfig& after session release (#76)

### DIFF
--- a/include/anira/backends/BackendBase.h
+++ b/include/anira/backends/BackendBase.h
@@ -25,11 +25,19 @@ public:
     /**
      * @brief Constructs a BackendBase with the given inference configuration
      *
-     * Initializes the backend processor with a reference to the inference configuration
+     * Initializes the backend processor with its own copy of the inference configuration
      * that contains all necessary parameters for model loading and processing.
      *
-     * @param inference_config Reference to the inference configuration containing
-     *                        model data, tensor shapes, and processing specifications
+     * The configuration is copied (not referenced) so that the processor's lifetime is
+     * fully decoupled from the session that created it. Processors are pooled and shared
+     * between sessions whose configs compare equal (see Context::set_processor); a shared
+     * processor can outlive the session that first created it. If it held a reference into
+     * that session's InferenceConfig, releasing the session while another session still
+     * shares the pooled processor would leave the reference dangling, causing a
+     * use-after-free on the next inference. Owning a copy removes that lifetime coupling.
+     *
+     * @param inference_config Reference to the inference configuration to copy from,
+     *                        containing model data, tensor shapes, and processing specifications
      */
     BackendBase(InferenceConfig& inference_config);
 
@@ -76,8 +84,10 @@ public:
                          std::vector<BufferF>& output,
                          [[maybe_unused]] std::shared_ptr<SessionElement> session);
 
-    InferenceConfig& m_inference_config;  ///< Reference to inference configuration containing model
-                                          ///< and processing parameters
+    InferenceConfig m_inference_config;  ///< Owned copy of the inference configuration containing
+                                         ///< model and processing parameters. Owned (not a
+                                         ///< reference) so a pooled processor shared across
+                                         ///< sessions never outlives the config it reads.
 };
 
 }  // namespace anira

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,6 +32,7 @@ target_sources(${PROJECT_NAME} PRIVATE
 	utils/test_Semaphore.cpp
 	utils/test_JsonConfigLoader.cpp
 	scheduler/test_InferenceManager.cpp
+	scheduler/test_ProcessorPooling.cpp
 	scheduler/test_SessionElement.cpp
 	scheduler/test_UserManagedThread.cpp
 	test_WavReader.cpp

--- a/test/scheduler/test_ProcessorPooling.cpp
+++ b/test/scheduler/test_ProcessorPooling.cpp
@@ -1,0 +1,102 @@
+#include <anira/ContextConfig.h>
+#include <anira/InferenceConfig.h>
+#include <anira/PrePostProcessor.h>
+#include <anira/scheduler/Context.h>
+
+#include <memory>
+
+#include "../../extras/models/hybrid-nn/HybridNNConfig.h"
+#include "gtest/gtest.h"
+
+using namespace anira;
+
+// Pick one real, pooled backend that is compiled into this build. The CUSTOM backend
+// is never pooled, so it cannot exercise the shared-processor lifetime path.
+#if defined(USE_LIBTORCH)
+#define POOL_PROCESSOR(session) ((session)->m_libtorch_processor)
+#define ANIRA_HAS_POOLED_BACKEND 1
+#elif defined(USE_ONNXRUNTIME)
+#define POOL_PROCESSOR(session) ((session)->m_onnx_processor)
+#define ANIRA_HAS_POOLED_BACKEND 1
+#elif defined(USE_TFLITE)
+#define POOL_PROCESSOR(session) ((session)->m_tflite_processor)
+#define ANIRA_HAS_POOLED_BACKEND 1
+#elif defined(USE_LITERT)
+#define POOL_PROCESSOR(session) ((session)->m_litert_processor)
+#define ANIRA_HAS_POOLED_BACKEND 1
+#else
+#define ANIRA_HAS_POOLED_BACKEND 0
+#endif
+
+#if ANIRA_HAS_POOLED_BACKEND
+
+// Regression test for issue #76 (use-after-free).
+//
+// Backend processors are pooled and shared between sessions whose configs compare
+// equal (the default, m_session_exclusive_processor == false). A shared processor
+// can therefore outlive the session that first created it. The host owns each
+// session's InferenceConfig, so releasing that first session destroys its config.
+// If the pooled processor held an `InferenceConfig&` bound to that config, the
+// reference would dangle and the next inference on the surviving session would
+// dereference freed memory.
+//
+// This reproduces the scenario at the Context level — two independently-owned
+// configs with equal values (e.g. two anira~ patches), sharing one pooled
+// processor, then the first is released and its config freed.
+//
+// We compare storage *addresses* rather than dereferencing the processor's config:
+// the whole point of the bug is that dereferencing it is undefined behaviour, so the
+// test must detect the dangling alias without triggering it. With the bug,
+// `&processor->m_inference_config` is the address of the now-freed config (the
+// reference's referent), so it equals the released storage. With the fix, the
+// processor owns its config in its own storage, so the addresses differ.
+TEST(ProcessorPoolingTest, PooledProcessorDoesNotAliasReleasedSessionConfig) {
+    ContextConfig const context_config;
+    auto context = Context::get_instance(context_config);
+
+    // Two hosts, each owning an equal-valued InferenceConfig. Session A's config is
+    // heap-allocated so its storage can be freed deterministically mid-test.
+    auto* config_a = new InferenceConfig(hybridnn_config);
+    auto* pp_a = new PrePostProcessor(*config_a);
+    auto session_a = context->create_session(*pp_a, *config_a, nullptr);
+
+    auto config_b = std::make_unique<InferenceConfig>(hybridnn_config);
+    auto pp_b = std::make_unique<PrePostProcessor>(*config_b);
+    auto session_b = context->create_session(*pp_b, *config_b, nullptr);
+
+    // Precondition: equal configs must actually share one pooled processor, otherwise
+    // the test would not exercise the bug at all.
+    ASSERT_NE(POOL_PROCESSOR(session_a), nullptr);
+    ASSERT_EQ(POOL_PROCESSOR(session_a), POOL_PROCESSOR(session_b))
+        << "Sessions with equal configs are expected to share one pooled processor";
+
+    // Keep the pooled processor alive independently so it can be inspected after
+    // session A is gone (this is what the Context's processor pool does internally).
+    auto pooled = POOL_PROCESSOR(session_b);
+    const void* released_config_storage = static_cast<const void*>(config_a);
+
+    // Release session A and free its config — exactly as a host destroying one plugin
+    // instance would. Session B and the pooled processor live on.
+    context->release_session(session_a);
+    session_a.reset();
+    delete pp_a;
+    delete config_a;  // Session A's InferenceConfig storage is now freed.
+
+    // The pooled processor is still in use by session B. It must not have its config
+    // sitting in session A's freed storage.
+    const void* processor_config_storage = static_cast<const void*>(&pooled->m_inference_config);
+    EXPECT_NE(processor_config_storage, released_config_storage)
+        << "Pooled processor still aliases the released session's InferenceConfig "
+           "(use-after-free, issue #76)";
+
+    // Cleanup: releasing the last session resets the Context singleton.
+    context->release_session(session_b);
+}
+
+#else
+
+TEST(ProcessorPoolingTest, DISABLED_RequiresPooledBackend) {
+    GTEST_SKIP() << "No pooled inference backend compiled in; nothing to exercise.";
+}
+
+#endif


### PR DESCRIPTION
Closes #76.

## Problem

`BackendBase::m_inference_config` was an `InferenceConfig&` bound to the config of the session that **first** created the processor. Backend processors are pooled and shared between sessions whose configs compare equal (the default, `m_session_exclusive_processor == false`), so a pooled processor can outlive that originating session.

Each session's `InferenceConfig` is owned by the host. When the originating session is released while a peer session keeps the pooled processor alive, the host frees that config — and the pooled processor's reference dangles. The next inference dereferences freed memory (`EXC_BAD_ACCESS` in an inference worker thread, observed in `anira~` when several patches are opened/closed before the DSP engine starts).

The backend `Instance`s (`LibtorchProcessor::Instance` etc.) inherit the problem: they're constructed with the base's `m_inference_config` and each stores its own `InferenceConfig&` aliasing it.

## Fix

Make `BackendBase::m_inference_config` an **owned value** instead of a reference, so the processor's config lifetime matches the processor. This fixes all four backends at once — each backend's `Instance` is constructed with the processor's `m_inference_config` and lives inside the processor, so the instances' `InferenceConfig&` now alias the processor-owned copy rather than a session's config.

Why it's safe:
- The pool keys on `operator==` (value equality), never identity, so sharing/dedup behaviour is unchanged.
- Nothing mutates the config through a processor and nothing depends on reference identity (verified by grep).
- `release_session` already copied the config, so `InferenceConfig` was already known-copyable.
- `SessionElement::m_inference_config` stays a reference (a session genuinely outlives its own host config), so latency/prepare logic is untouched.

This supersedes the `m_session_exclusive_processor = true` workaround: sharing between equal-config sessions is preserved, with the lifetime bug removed.

## Regression test

`test/scheduler/test_ProcessorPooling.cpp` reproduces the scenario at the `Context` level: two independently-owned, equal-valued configs share one pooled processor; the first session is released and its config freed; the test asserts the pooled processor's config no longer lives in that freed storage. It compares storage **addresses** (rather than dereferencing) so it detects the dangling alias deterministically without triggering the UB it guards against — no sanitizer required.

The first commit adds the test (fails on the old code: `0x1037b4bf0 vs 0x1037b4bf0`); the second commit applies the fix (test passes).

## Verification

- Regression test fails on the buggy code, passes after the fix.
- Full suite: **193/193 passed**, across ONNX+TFLite and LiteRT backend configurations.